### PR TITLE
Add configurable tray queue and display ordering

### DIFF
--- a/app_core/app.py
+++ b/app_core/app.py
@@ -42,6 +42,7 @@ from notifications import TelegramNotifier, DiscordNotifier
 from .power_control import PowerControl
 from .system_usage import SystemUsage
 from .click_tracker import increment_keyboard, increment_mouse, get_counts
+from .tray_display import normalize_tray_order, parse_tray_order_text, ordered_tray_parts
 
 
 
@@ -77,6 +78,19 @@ class SystemTrayApp:
             self.visibility_settings['language'] = detect_system_language()
             self.save_settings()
         set_language(self.visibility_settings['language'])
+        self.visibility_settings['tray_display_order'] = normalize_tray_order(
+            self.visibility_settings.get('tray_display_order')
+        )
+        self.visibility_settings['tray_cycle_enabled'] = bool(self.visibility_settings.get('tray_cycle_enabled', False))
+        try:
+            cycle_interval = int(self.visibility_settings.get('tray_cycle_interval_sec', 3))
+        except (TypeError, ValueError):
+            cycle_interval = 3
+        self.visibility_settings['tray_cycle_interval_sec'] = max(1, min(cycle_interval, 3600))
+
+        self._tray_cycle_index = 0
+        self._last_tray_cycle_at = 0.0
+
 
         self.indicator = AppInd.Indicator.new(APP_ID, ICON_FALLBACK, AppInd.IndicatorCategory.SYSTEM_SERVICES)
         icon_candidates = [
@@ -417,6 +431,7 @@ class SystemTrayApp:
             'language': None, 'logging_enabled': True,
             'show_power_off': True, 'show_reboot': True, 'show_lock': True, 'show_timer': True,
             'max_log_mb': 5, 'ping_network': True, 'show_system_info': True,
+            'tray_display_order': ['cpu', 'ram'], 'tray_cycle_enabled': False, 'tray_cycle_interval_sec': 3,
         }
         try:
             if self.settings_file.exists():
@@ -501,6 +516,11 @@ class SystemTrayApp:
                 vs['logging_enabled'] = dialog.logging_check.get_active()
                 vs['ping_network'] = dialog.ping_check.get_active()
                 vs['show_system_info'] = dialog.system_info_check.get_active()
+                vs['tray_cycle_enabled'] = dialog.tray_cycle_check.get_active()
+                vs['tray_cycle_interval_sec'] = int(dialog.tray_cycle_interval_spin.get_value())
+                vs['tray_display_order'] = parse_tray_order_text(dialog.tray_order_entry.get_text())
+                self._tray_cycle_index = 0
+                self._last_tray_cycle_at = 0.0
                 vs['max_log_mb'] = int(dialog.logsize_spin.get_value())
 
                 tel_enabled_before = getattr(self, 'telegram_notifier', TelegramNotifier()).enabled
@@ -1705,14 +1725,31 @@ class SystemTrayApp:
             if self.visibility_settings.get('mouse_clicks', True):
                 self.mouse_item.set_label(f"{tr('mouse_clicks')}: {mouse_clicks_val}")
 
-            tray_parts = []
+            parts_by_key = {}
             if self.visibility_settings.get('tray_cpu', True):
-                tray_parts.append(f"{tr('cpu_info')}: {cpu_usage:.0f}%")
+                parts_by_key['cpu'] = f"{tr('cpu_info')}: {cpu_usage:.0f}%"
             if self.visibility_settings.get('tray_ram', True):
-                tray_parts.append(f"{tr('ram_loading')}: {ram_used:.1f}GB")
-            tray_text = "  ".join(tray_parts)
+                parts_by_key['ram'] = f"{tr('ram_loading')}: {ram_used:.1f}GB"
+
+            tray_parts = ordered_tray_parts(parts_by_key, self.visibility_settings.get('tray_display_order'))
+
+            tray_text = ""
+            if tray_parts:
+                if self.visibility_settings.get('tray_cycle_enabled', False):
+                    now = time.time()
+                    interval = max(1, int(self.visibility_settings.get('tray_cycle_interval_sec', 3)))
+                    if self._last_tray_cycle_at <= 0:
+                        self._tray_cycle_index = 0
+                        self._last_tray_cycle_at = now
+                    elif now - self._last_tray_cycle_at >= interval:
+                        self._tray_cycle_index = (self._tray_cycle_index + 1) % len(tray_parts)
+                        self._last_tray_cycle_at = now
+                    tray_text = tray_parts[self._tray_cycle_index % len(tray_parts)]
+                else:
+                    tray_text = "  ".join(tray_parts)
+
             if self.telegram_notifier.enabled or self.discord_notifier.enabled:
-                tray_text = "⤴  " + tray_text
+                tray_text = ("⤴  " + tray_text) if tray_text else "⤴"
             self.indicator.set_label(tray_text, "")
         except Exception as e:
             print(f"Ошибка в _update_ui: {e}")

--- a/app_core/dialogs.py
+++ b/app_core/dialogs.py
@@ -10,6 +10,7 @@ from .click_tracker import get_counts
 from .constants import LOG_FILE, TELEGRAM_CONFIG_FILE, DISCORD_CONFIG_FILE
 from .localization import tr
 from notifications import TelegramNotifier, DiscordNotifier
+from .tray_display import normalize_tray_order
 
 
 class SettingsDialog(Gtk.Dialog):
@@ -40,6 +41,33 @@ class SettingsDialog(Gtk.Dialog):
 
         self.tray_cpu_check = add_check('cpu_tray', 'tray_cpu')
         self.tray_ram_check = add_check('ram_tray', 'tray_ram')
+
+        tray_cycle_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
+        self.tray_cycle_check = Gtk.CheckButton(label=tr('tray_cycle_enabled'))
+        self.tray_cycle_check.set_active(bool(self.visibility_settings.get('tray_cycle_enabled', False)))
+        tray_cycle_box.pack_start(self.tray_cycle_check, False, False, 0)
+
+        cycle_label = Gtk.Label(label=tr('tray_cycle_interval_sec'))
+        cycle_label.set_xalign(0)
+        tray_cycle_box.pack_start(cycle_label, False, False, 0)
+
+        self.tray_cycle_interval_spin = Gtk.SpinButton.new_with_range(1, 3600, 1)
+        self.tray_cycle_interval_spin.set_value(int(self.visibility_settings.get('tray_cycle_interval_sec', 3)))
+        tray_cycle_box.pack_start(self.tray_cycle_interval_spin, False, False, 0)
+        box.add(tray_cycle_box)
+
+        tray_order_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
+        tray_order_label = Gtk.Label(label=tr('tray_order'))
+        tray_order_label.set_xalign(0)
+        tray_order_box.pack_start(tray_order_label, False, False, 0)
+
+        self.tray_order_entry = Gtk.Entry()
+        self.tray_order_entry.set_placeholder_text('cpu, ram')
+        current_order = normalize_tray_order(self.visibility_settings.get('tray_display_order'))
+        self.tray_order_entry.set_text(', '.join(current_order))
+        tray_order_box.pack_start(self.tray_order_entry, True, True, 0)
+        box.add(tray_order_box)
+
         box.add(Gtk.Separator(orientation=Gtk.Orientation.HORIZONTAL))
 
         self.cpu_check = add_check('cpu_info', 'cpu')

--- a/app_core/language.py
+++ b/app_core/language.py
@@ -2,6 +2,9 @@ LANGUAGES = {
     'ru': {
         'cpu_tray': "ЦПУ в трее",
         'ram_tray': "ОЗУ в трее",
+        'tray_cycle_enabled': 'Очередь в трее',
+        'tray_cycle_interval_sec': 'Интервал очереди (сек.):',
+        'tray_order': 'Порядок в трее (cpu, ram):',
         'cpu_info': " ЦПУ",
         'ram_loading': "ОЗУ",
         'swap_loading': "Подкачка",
@@ -105,6 +108,9 @@ LANGUAGES = {
     'en': {
         'cpu_tray': "CPU in tray",
         'ram_tray': "RAM in tray",
+        'tray_cycle_enabled': 'Queue mode in tray',
+        'tray_cycle_interval_sec': 'Queue interval (sec.):',
+        'tray_order': 'Tray order (cpu, ram):',
         'cpu_info': " CPU",
         'ram_loading': "RAM",
         'swap_loading': "Swap",
@@ -208,6 +214,9 @@ LANGUAGES = {
     'cn': {
         'cpu_tray': "CPU在托盘",
         'ram_tray': "内存托盘显示",
+        'tray_cycle_enabled': '托盘队列模式',
+        'tray_cycle_interval_sec': '队列间隔（秒）:',
+        'tray_order': '托盘顺序（cpu, ram）:',
         'cpu_info': " 处理器",
         'ram_loading': "内存",
         'swap_loading': "交换分区",
@@ -311,6 +320,9 @@ LANGUAGES = {
     'de': {
         'cpu_tray': "CPU im Tray",
         'ram_tray': "RAM im Tray",
+        'tray_cycle_enabled': 'Warteschlange im Tray',
+        'tray_cycle_interval_sec': 'Intervall der Warteschlange (Sek.):',
+        'tray_order': 'Reihenfolge im Tray (cpu, ram):',
         'cpu_info': " CPU",
         'ram_loading': "RAM",
         'swap_loading': "Auslagerung",
@@ -415,6 +427,9 @@ LANGUAGES = {
     'it': {
         'cpu_tray': "CPU in tray",
         'ram_tray': "RAM in tray",
+        'tray_cycle_enabled': 'Queue mode in tray',
+        'tray_cycle_interval_sec': 'Queue interval (sec.):',
+        'tray_order': 'Tray order (cpu, ram):',
         'cpu_info': " CPU",
         'ram_loading': "RAM",
         'swap_loading': "Swap",
@@ -518,6 +533,9 @@ LANGUAGES = {
     'es': {
         'cpu_tray': "CPU en bandeja",
         'ram_tray': "RAM en bandeja",
+        'tray_cycle_enabled': 'Modo cola en bandeja',
+        'tray_cycle_interval_sec': 'Intervalo de cola (seg.):',
+        'tray_order': 'Orden en bandeja (cpu, ram):',
         'cpu_info': " CPU",
         'ram_loading': "RAM",
         'swap_loading': "Swap",
@@ -621,6 +639,9 @@ LANGUAGES = {
     'tr': {
         'cpu_tray': "Sistem çekmecesinde CPU",
         'ram_tray': "Sistem çekmecesinde RAM",
+        'tray_cycle_enabled': 'Tepside sıra modu',
+        'tray_cycle_interval_sec': 'Sıra aralığı (sn):',
+        'tray_order': 'Tepsi sırası (cpu, ram):',
         'cpu_info': " CPU",
         'ram_loading': "RAM",
         'swap_loading': "Takas",
@@ -724,6 +745,9 @@ LANGUAGES = {
     'fr': {
         'cpu_tray': "CPU dans la barre",
         'ram_tray': "RAM dans la barre",
+        'tray_cycle_enabled': 'Mode file dans la barre',
+        'tray_cycle_interval_sec': 'Intervalle de file (sec.) :',
+        'tray_order': 'Ordre dans la barre (cpu, ram) :',
         'cpu_info': " CPU",
         'ram_loading': "RAM",
         'swap_loading': "Swap",

--- a/app_core/tray_display.py
+++ b/app_core/tray_display.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from typing import Iterable, Mapping
+
+
+DEFAULT_TRAY_ORDER = ["cpu", "ram"]
+SUPPORTED_TRAY_KEYS = ["cpu", "ram"]
+
+
+def normalize_tray_order(raw_order: Iterable[str] | None) -> list[str]:
+    if raw_order is None:
+        return DEFAULT_TRAY_ORDER.copy()
+
+    normalized: list[str] = []
+    seen: set[str] = set()
+
+    for key in raw_order:
+        key_norm = str(key).strip().lower()
+        if key_norm in SUPPORTED_TRAY_KEYS and key_norm not in seen:
+            normalized.append(key_norm)
+            seen.add(key_norm)
+
+    for key in DEFAULT_TRAY_ORDER:
+        if key not in seen:
+            normalized.append(key)
+
+    return normalized
+
+
+def parse_tray_order_text(raw_text: str) -> list[str]:
+    parts = [p.strip().lower() for p in raw_text.replace(";", ",").split(",") if p.strip()]
+    return normalize_tray_order(parts)
+
+
+def ordered_tray_parts(parts_by_key: Mapping[str, str], tray_order: Iterable[str]) -> list[str]:
+    parts: list[str] = []
+    for key in normalize_tray_order(tray_order):
+        value = parts_by_key.get(key)
+        if value:
+            parts.append(value)
+    return parts
+

--- a/tests/test_system_info_visibility_setting.py
+++ b/tests/test_system_info_visibility_setting.py
@@ -10,3 +10,16 @@ def test_show_system_info_setting_is_wired_in_app_and_dialog():
     assert "vs['show_system_info'] = dialog.system_info_check.get_active()" in app_code
 
     assert "self.system_info_check = add_check('system_info', 'show_system_info')" in dialogs_code
+
+
+def test_tray_order_and_queue_settings_are_wired_in_app_and_dialog():
+    app_code = Path('app_core/app.py').read_text(encoding='utf-8')
+    dialogs_code = Path('app_core/dialogs.py').read_text(encoding='utf-8')
+
+    assert "'tray_display_order': ['cpu', 'ram']" in app_code
+    assert "'tray_cycle_enabled': False" in app_code
+    assert "vs['tray_display_order'] = parse_tray_order_text(dialog.tray_order_entry.get_text())" in app_code
+    assert "vs['tray_cycle_enabled'] = dialog.tray_cycle_check.get_active()" in app_code
+
+    assert "self.tray_cycle_check = Gtk.CheckButton(label=tr('tray_cycle_enabled'))" in dialogs_code
+    assert "self.tray_order_entry = Gtk.Entry()" in dialogs_code

--- a/tests/test_tray_display_order.py
+++ b/tests/test_tray_display_order.py
@@ -1,0 +1,22 @@
+from app_core.tray_display import (
+    normalize_tray_order,
+    ordered_tray_parts,
+    parse_tray_order_text,
+)
+
+
+def test_normalize_tray_order_removes_invalid_and_duplicates():
+    assert normalize_tray_order(["ram", "cpu", "ram", "bad"]) == ["ram", "cpu"]
+
+
+def test_normalize_tray_order_falls_back_to_default():
+    assert normalize_tray_order([]) == ["cpu", "ram"]
+
+
+def test_parse_tray_order_text_supports_semicolon_separator():
+    assert parse_tray_order_text("ram; cpu") == ["ram", "cpu"]
+
+
+def test_ordered_tray_parts_uses_requested_order():
+    parts = ordered_tray_parts({"cpu": "CPU: 20%", "ram": "RAM: 3.1GB"}, ["ram", "cpu"])
+    assert parts == ["RAM: 3.1GB", "CPU: 20%"]


### PR DESCRIPTION
### Motivation
- Make the tray text flexible and user-configurable so users can choose which parts appear and in what order. 
- Provide an optional queue/cycle mode to rotate displayed tray segments when space is limited. 
- Centralize tray-order parsing/normalization to keep runtime code simpler and robust to malformed user input.

### Description
- Added `app_core/tray_display.py` with `normalize_tray_order`, `parse_tray_order_text`, and `ordered_tray_parts` helpers to validate and build ordered tray segments. 
- Extended runtime settings in `app_core/app.py` with defaults and validation for `tray_display_order`, `tray_cycle_enabled`, and `tray_cycle_interval_sec`, and implemented tray-label rendering and cycling logic in `_update_ui`. 
- Updated `app_core/dialogs.py` to add UI controls (`tray_cycle_check`, `tray_cycle_interval_spin`, `tray_order_entry`) and to persist user changes via `parse_tray_order_text`. 
- Added localization keys for the new controls into `app_core/language.py` for all supported languages. 
- Added `tests/test_tray_display_order.py` and extended `tests/test_system_info_visibility_setting.py` to cover parsing/normalization and wiring between the dialog and app.

### Testing
- Ran `pytest -q` and all tests passed: `23 passed`.
- New unit tests include `tests/test_tray_display_order.py` which verifies parsing/normalization and `tests/test_system_info_visibility_setting.py` was updated to assert new settings are wired in the code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69adb8750f20832681249e71e5cb13e2)