### PR TITLE
Add threshold-based red highlighting for CPU, temperature, RAM, Disk and Swap

### DIFF
--- a/app_core/app.py
+++ b/app_core/app.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import html
 import platform
 from collections import deque
 from datetime import datetime
@@ -70,6 +71,12 @@ LANGUAGE_FLAGS = {
 
 
 class SystemTrayApp:
+    CPU_ALERT_THRESHOLD = 90.0
+    CPU_TEMP_ALERT_THRESHOLD = 80
+    RAM_ALERT_THRESHOLD = 90.0
+    DISK_ALERT_THRESHOLD = 90.0
+    SWAP_ALERT_THRESHOLD = 90.0
+
     def __init__(self):
         self.settings_file = SETTINGS_FILE
         self.visibility_settings = self.load_settings()
@@ -1688,14 +1695,35 @@ class SystemTrayApp:
             if self.mouse_graph_area:
                 self.mouse_graph_area.queue_draw()
 
+            ram_usage_percent = (ram_used / ram_total * 100) if ram_total > 0 else 0.0
+            swap_usage_percent = (swap_used / swap_total * 100) if swap_total > 0 else 0.0
+            disk_usage_percent = (disk_used / disk_total * 100) if disk_total > 0 else 0.0
+
             if self.visibility_settings.get('cpu', True):
-                self.cpu_temp_item.set_label(f"{tr('cpu_info')}: {cpu_usage:.0f}%  🌡{cpu_temp}°C")
+                cpu_alert = cpu_usage > self.CPU_ALERT_THRESHOLD or cpu_temp > self.CPU_TEMP_ALERT_THRESHOLD
+                self._set_menu_item_alert_label(
+                    self.cpu_temp_item,
+                    f"{tr('cpu_info')}: {cpu_usage:.0f}%  🌡{cpu_temp}°C",
+                    cpu_alert,
+                )
             if self.visibility_settings.get('ram', True):
-                self.ram_item.set_label(f"{tr('ram_loading')}: {ram_used:.1f}/{ram_total:.1f} GB")
+                self._set_menu_item_alert_label(
+                    self.ram_item,
+                    f"{tr('ram_loading')}: {ram_used:.1f}/{ram_total:.1f} GB",
+                    ram_usage_percent > self.RAM_ALERT_THRESHOLD,
+                )
             if self.visibility_settings.get('swap', True):
-                self.swap_item.set_label(f"{tr('swap_loading')}: {swap_used:.1f}/{swap_total:.1f} GB")
+                self._set_menu_item_alert_label(
+                    self.swap_item,
+                    f"{tr('swap_loading')}: {swap_used:.1f}/{swap_total:.1f} GB",
+                    swap_usage_percent > self.SWAP_ALERT_THRESHOLD,
+                )
             if self.visibility_settings.get('disk', True):
-                self.disk_item.set_label(f"{tr('disk_loading')}: {disk_used:.1f}/{disk_total:.1f} GB")
+                self._set_menu_item_alert_label(
+                    self.disk_item,
+                    f"{tr('disk_loading')}: {disk_used:.1f}/{disk_total:.1f} GB",
+                    disk_usage_percent > self.DISK_ALERT_THRESHOLD,
+                )
             if self.visibility_settings.get('net', True):
                 self.net_item.set_label(f"{tr('lan_speed')}: ↓{net_recv_speed:.1f}/↑{net_sent_speed:.1f} MB/s")
             if self.visibility_settings.get('uptime', True):
@@ -1716,6 +1744,18 @@ class SystemTrayApp:
             self.indicator.set_label(tray_text, "")
         except Exception as e:
             print(f"Ошибка в _update_ui: {e}")
+
+    @staticmethod
+    def _set_menu_item_alert_label(item: Gtk.MenuItem, text: str, is_alert: bool) -> None:
+        label_widget = item.get_child()
+        if isinstance(label_widget, Gtk.Label):
+            escaped_text = html.escape(text)
+            if is_alert:
+                label_widget.set_markup(f'<span foreground="red">{escaped_text}</span>')
+            else:
+                label_widget.set_markup(escaped_text)
+            return
+        item.set_label(text)
 
     def quit(self, *args):
         if self.telegram_notifier:

--- a/app_core/app.py
+++ b/app_core/app.py
@@ -24,7 +24,7 @@ except (ValueError, ImportError):
 gi.require_version("Gtk", "3.0")
 
 import psutil
-from gi.repository import Gtk, GLib
+from gi.repository import Gtk, GLib, Gdk
 from pynput import keyboard, mouse
 
 from .constants import (
@@ -1746,14 +1746,36 @@ class SystemTrayApp:
             print(f"Ошибка в _update_ui: {e}")
 
     @staticmethod
-    def _set_menu_item_alert_label(item: Gtk.MenuItem, text: str, is_alert: bool) -> None:
-        label_widget = item.get_child()
+    def _find_menu_item_label(item: Gtk.MenuItem) -> Optional[Gtk.Label]:
+        child = item.get_child()
+        if isinstance(child, Gtk.Label):
+            return child
+        if isinstance(child, Gtk.Container):
+            stack = list(child.get_children())
+            while stack:
+                node = stack.pop()
+                if isinstance(node, Gtk.Label):
+                    return node
+                if isinstance(node, Gtk.Container):
+                    stack.extend(node.get_children())
+        return None
+
+    @classmethod
+    def _set_menu_item_alert_label(cls, item: Gtk.MenuItem, text: str, is_alert: bool) -> None:
+        label_widget = cls._find_menu_item_label(item)
         if isinstance(label_widget, Gtk.Label):
             escaped_text = html.escape(text)
             if is_alert:
-                label_widget.set_markup(f'<span foreground="red">{escaped_text}</span>')
+                label_widget.set_use_markup(True)
+                label_widget.set_markup(f'<span color="#ff3b30"><b>{escaped_text}</b></span>')
+                alert_color = Gdk.RGBA(1.0, 0.23, 0.19, 1.0)
+                label_widget.override_color(Gtk.StateFlags.NORMAL, alert_color)
+                label_widget.override_color(Gtk.StateFlags.PRELIGHT, alert_color)
             else:
-                label_widget.set_markup(escaped_text)
+                label_widget.override_color(Gtk.StateFlags.NORMAL, None)
+                label_widget.override_color(Gtk.StateFlags.PRELIGHT, None)
+                label_widget.set_use_markup(False)
+                label_widget.set_text(text)
             return
         item.set_label(text)
 


### PR DESCRIPTION
### Motivation
- Make system metric items in the tray menu visually indicate critical conditions by coloring them red when they exceed sensible thresholds.
- Treat CPU temperature separately so very hot CPUs are also highlighted even if usage is moderate.
- Keep highlighting reversible and localized to the tray/menu items so normal UI flow is preserved.

### Description
- Added alert threshold constants to `SystemTrayApp`: `CPU_ALERT_THRESHOLD=90.0`, `CPU_TEMP_ALERT_THRESHOLD=80`, `RAM_ALERT_THRESHOLD=90.0`, `DISK_ALERT_THRESHOLD=90.0`, and `SWAP_ALERT_THRESHOLD=90.0` in `app_core/app.py`.
- Updated `_update_ui` to compute percentage usage for RAM, Swap and Disk and to determine CPU alert when either usage or temperature exceeds thresholds.
- Added helper method `_set_menu_item_alert_label` which escapes text via `html.escape` and uses GTK markup (`set_markup`) to render the metric text in red when `is_alert` is true, falling back to `set_label` when needed.
- Changes are implemented in `app_core/app.py` and apply red highlighting to the CPU (usage or temp), RAM, Swap and Disk menu rows.

### Testing
- Ran `python -m py_compile /workspace/SyMo/app_core/app.py` and the file compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b599400b148326a64a00855fb49bae)