### PR TITLE
Add GNOME Extensions upload packaging support

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,25 @@ pip install -r requirements.txt
 python3 app.py
 ```
 
+
+## GNOME Extensions upload package
+
+The repository now includes `gnome_extension/` with a minimal GNOME Shell extension (`metadata.json` and `extension.js`) that adds a panel launcher for SyMo.
+
+Build the zip archive for <https://extensions.gnome.org/upload/>:
+
+```bash
+chmod +x package-gnome-extension.sh
+./package-gnome-extension.sh
+```
+
+By default, the package is created at `dist/symo@olegegoism.github.io.zip`.
+
+Before uploading, verify:
+- UUID in `gnome_extension/metadata.json`;
+- supported `shell-version` values;
+- local install works (`gnome-extensions install --force dist/symo@olegegoism.github.io.zip`).
+
 ## Build
 
 `build.sh` performs:

--- a/README_RU.md
+++ b/README_RU.md
@@ -93,6 +93,25 @@ pip install -r requirements.txt
 python3 app.py
 ```
 
+
+## Пакет для GNOME Extensions
+
+В репозитории добавлена папка `gnome_extension/` с минимальным GNOME Shell extension (`metadata.json` и `extension.js`) для запуска приложения SyMo из панели GNOME.
+
+Собрать zip-архив для загрузки на <https://extensions.gnome.org/upload/>:
+
+```bash
+chmod +x package-gnome-extension.sh
+./package-gnome-extension.sh
+```
+
+По умолчанию архив создаётся в `dist/symo@olegegoism.github.io.zip`.
+
+Перед загрузкой проверьте:
+- UUID в `gnome_extension/metadata.json`;
+- поддерживаемые версии `shell-version`;
+- что расширение корректно устанавливается локально (`gnome-extensions install --force dist/symo@olegegoism.github.io.zip`).
+
 ## Сборка
 
 `build.sh` выполняет:

--- a/gnome_extension/extension.js
+++ b/gnome_extension/extension.js
@@ -1,0 +1,62 @@
+import Gio from 'gi://Gio';
+import St from 'gi://St';
+
+import * as Main from 'resource:///org/gnome/shell/ui/main.js';
+import * as PanelMenu from 'resource:///org/gnome/shell/ui/panelMenu.js';
+import * as PopupMenu from 'resource:///org/gnome/shell/ui/popupMenu.js';
+
+const UUID = 'symo@olegegoism.github.io';
+const APP_BINARY = 'SyMo';
+
+class SyMoLauncherIndicator extends PanelMenu.Button {
+    constructor() {
+        super(0.0, 'SyMo Launcher');
+
+        this._icon = new St.Icon({
+            icon_name: 'utilities-system-monitor-symbolic',
+            style_class: 'system-status-icon',
+        });
+        this.add_child(this._icon);
+
+        this._openItem = new PopupMenu.PopupMenuItem('Open SyMo');
+        this._openItem.connect('activate', () => this._launchSyMo());
+        this.menu.addMenuItem(this._openItem);
+
+        this._separator = new PopupMenu.PopupSeparatorMenuItem();
+        this.menu.addMenuItem(this._separator);
+
+        this._aboutItem = new PopupMenu.PopupMenuItem('About SyMo');
+        this._aboutItem.connect('activate', () => {
+            Main.notify('SyMo', 'SyMo launcher extension is active.');
+        });
+        this.menu.addMenuItem(this._aboutItem);
+    }
+
+    _launchSyMo() {
+        try {
+            const appInfo = Gio.AppInfo.create_from_commandline(
+                APP_BINARY,
+                'SyMo',
+                Gio.AppInfoCreateFlags.NONE
+            );
+            appInfo.launch([], null);
+        } catch (error) {
+            log(`[${UUID}] Failed to start SyMo: ${error}`);
+            Main.notify('SyMo', 'Unable to start SyMo. Ensure SyMo is installed and available in PATH.');
+        }
+    }
+}
+
+export default class SyMoExtension {
+    enable() {
+        this._indicator = new SyMoLauncherIndicator();
+        Main.panel.addToStatusArea(UUID, this._indicator);
+    }
+
+    disable() {
+        if (this._indicator) {
+            this._indicator.destroy();
+            this._indicator = null;
+        }
+    }
+}

--- a/gnome_extension/metadata.json
+++ b/gnome_extension/metadata.json
@@ -1,0 +1,8 @@
+{
+  "uuid": "symo@olegegoism.github.io",
+  "name": "SyMo Launcher",
+  "description": "GNOME Shell panel launcher for the SyMo system monitor app.",
+  "shell-version": ["45", "46", "47", "48"],
+  "version": 1,
+  "url": "https://github.com/OlegEgoism/SyMo"
+}

--- a/package-gnome-extension.sh
+++ b/package-gnome-extension.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SRC_DIR="${1:-gnome_extension}"
+DIST_DIR="${2:-dist}"
+
+if [[ ! -d "$SRC_DIR" ]]; then
+  echo "Error: source directory '$SRC_DIR' not found." >&2
+  exit 1
+fi
+
+if [[ ! -f "$SRC_DIR/metadata.json" ]]; then
+  echo "Error: '$SRC_DIR/metadata.json' is required for GNOME extension packaging." >&2
+  exit 1
+fi
+
+if [[ ! -f "$SRC_DIR/extension.js" ]]; then
+  echo "Error: '$SRC_DIR/extension.js' is required for GNOME extension packaging." >&2
+  exit 1
+fi
+
+UUID=$(python3 - <<'PY' "$SRC_DIR/metadata.json"
+import json,sys
+with open(sys.argv[1], 'r', encoding='utf-8') as f:
+    print(json.load(f)['uuid'])
+PY
+)
+
+if [[ -z "$UUID" ]]; then
+  echo "Error: uuid in metadata.json is empty." >&2
+  exit 1
+fi
+
+mkdir -p "$DIST_DIR"
+OUT_FILE="$DIST_DIR/${UUID}.zip"
+
+(
+  cd "$SRC_DIR"
+  rm -f "$OUT_FILE"
+  zip -qr "../${OUT_FILE}" .
+)
+
+echo "GNOME extension package created: $OUT_FILE"


### PR DESCRIPTION
### Motivation
- Provide an upload-ready GNOME Shell extension package that lets users add a simple panel launcher for SyMo to GNOME and upload it to https://extensions.gnome.org/upload/.
- Make it easy to produce the correct ZIP named after the extension UUID for the GNOME Extensions upload flow.

### Description
- Added `gnome_extension/metadata.json` containing `uuid`, `name`, `shell-version`, and project `url` for the extension.
- Added `gnome_extension/extension.js` implementing a minimal panel indicator with an "Open SyMo" menu item that launches the `SyMo` binary.
- Added `package-gnome-extension.sh` which validates required files, reads the UUID from `metadata.json`, and creates `dist/<uuid>.zip` suitable for upload.
- Updated `README.md` and `README_RU.md` with instructions to build and verify the GNOME extension upload package.

### Testing
- Ran `./package-gnome-extension.sh` and confirmed the ZIP was created successfully at `dist/symo@olegegoism.github.io.zip`.
- Ran `unzip -l dist/symo@olegegoism.github.io.zip` to verify archive contents and entry names were correct.
- Ran `pytest -q tests/test_build_artifacts_bundle.py` which passed (`2 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b6f552078c83268a8c7a559dcee668)