### PR TITLE
Add horizontal zoom support for all monitoring charts

### DIFF
--- a/app_core/app.py
+++ b/app_core/app.py
@@ -23,7 +23,7 @@ except (ValueError, ImportError):
 gi.require_version("Gtk", "3.0")
 
 import psutil
-from gi.repository import Gtk, GLib, Gdk
+from gi.repository import Gtk, GLib
 from pynput import keyboard, mouse
 
 from .constants import (
@@ -439,29 +439,33 @@ class SystemTrayApp:
         self.keyboard_history = deque(self.keyboard_history, maxlen=maxlen)
         self.mouse_history = deque(self.mouse_history, maxlen=maxlen)
 
-    def _configure_graph_area(self, area: Gtk.DrawingArea, graph_key: str) -> None:
-        area.add_events(Gdk.EventMask.SCROLL_MASK)
-        area.connect("scroll-event", self._on_graph_scroll, graph_key)
+    def _create_graph_zoom_control(self, graph_key: str) -> Gtk.Box:
+        row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
+        label = Gtk.Label(label=tr('graph_zoom_label'))
+        label.set_xalign(0)
+        row.pack_start(label, False, False, 0)
 
-    def _on_graph_scroll(self, widget, event, graph_key: str):
+        scale = Gtk.Scale.new_with_range(Gtk.Orientation.HORIZONTAL, 1.0, 32.0, 0.5)
+        scale.set_hexpand(True)
+        scale.set_digits(1)
+        scale.set_draw_value(True)
+        scale.set_value(self.graph_zoom.get(graph_key, 1.0))
+        scale.connect("value-changed", self._on_graph_zoom_changed, graph_key)
+        row.pack_start(scale, True, True, 0)
+        return row
+
+    def _on_graph_zoom_changed(self, scale: Gtk.Scale, graph_key: str) -> None:
         if graph_key not in self.graph_zoom:
-            return False
+            return
 
-        zoom = self.graph_zoom[graph_key]
-        if event.direction == Gdk.ScrollDirection.UP:
-            zoom = min(32.0, zoom * 1.25)
-        elif event.direction == Gdk.ScrollDirection.DOWN:
-            zoom = max(1.0, zoom / 1.25)
-        elif event.direction == Gdk.ScrollDirection.SMOOTH:
-            if event.delta_y < 0:
-                zoom = min(32.0, zoom * 1.25)
-            elif event.delta_y > 0:
-                zoom = max(1.0, zoom / 1.25)
-
+        zoom = max(1.0, min(32.0, float(scale.get_value())))
         self.graph_zoom[graph_key] = zoom
-        widget.queue_draw()
+
+        area = getattr(self, f"{graph_key}_graph_area", None)
+        if area:
+            area.queue_draw()
+
         self._refresh_graph_hints()
-        return True
 
     def _get_zoomed_samples(self, history, graph_key: str):
         samples = list(history)
@@ -764,9 +768,11 @@ class SystemTrayApp:
         hint.set_xalign(0)
         box.pack_start(hint, False, False, 0)
 
+        zoom_control = self._create_graph_zoom_control("cpu")
+        box.pack_start(zoom_control, False, False, 0)
+
         area = Gtk.DrawingArea()
         area.set_size_request(680, 320)
-        self._configure_graph_area(area, "cpu")
         area.connect("draw", self._draw_cpu_graph)
         box.pack_start(area, True, True, 0)
 
@@ -934,9 +940,11 @@ class SystemTrayApp:
         hint.set_xalign(0)
         box.pack_start(hint, False, False, 0)
 
+        zoom_control = self._create_graph_zoom_control("ram")
+        box.pack_start(zoom_control, False, False, 0)
+
         area = Gtk.DrawingArea()
         area.set_size_request(680, 320)
-        self._configure_graph_area(area, "ram")
         area.connect("draw", self._draw_ram_graph)
         box.pack_start(area, True, True, 0)
 
@@ -1070,9 +1078,11 @@ class SystemTrayApp:
         hint.set_xalign(0)
         box.pack_start(hint, False, False, 0)
 
+        zoom_control = self._create_graph_zoom_control("swap")
+        box.pack_start(zoom_control, False, False, 0)
+
         area = Gtk.DrawingArea()
         area.set_size_request(680, 320)
-        self._configure_graph_area(area, "swap")
         area.connect("draw", self._draw_swap_graph)
         box.pack_start(area, True, True, 0)
 
@@ -1206,9 +1216,11 @@ class SystemTrayApp:
         hint.set_xalign(0)
         box.pack_start(hint, False, False, 0)
 
+        zoom_control = self._create_graph_zoom_control("disk")
+        box.pack_start(zoom_control, False, False, 0)
+
         area = Gtk.DrawingArea()
         area.set_size_request(680, 320)
-        self._configure_graph_area(area, "disk")
         area.connect("draw", self._draw_disk_graph)
         box.pack_start(area, True, True, 0)
 
@@ -1343,9 +1355,11 @@ class SystemTrayApp:
         hint.set_xalign(0)
         box.pack_start(hint, False, False, 0)
 
+        zoom_control = self._create_graph_zoom_control("net")
+        box.pack_start(zoom_control, False, False, 0)
+
         area = Gtk.DrawingArea()
         area.set_size_request(680, 320)
-        self._configure_graph_area(area, "net")
         area.connect("draw", self._draw_net_graph)
         box.pack_start(area, True, True, 0)
 
@@ -1489,9 +1503,11 @@ class SystemTrayApp:
         hint.set_xalign(0)
         box.pack_start(hint, False, False, 0)
 
+        zoom_control = self._create_graph_zoom_control("keyboard")
+        box.pack_start(zoom_control, False, False, 0)
+
         area = Gtk.DrawingArea()
         area.set_size_request(680, 320)
-        self._configure_graph_area(area, "keyboard")
         area.connect("draw", self._draw_keyboard_graph)
         box.pack_start(area, True, True, 0)
 
@@ -1623,9 +1639,11 @@ class SystemTrayApp:
         hint.set_xalign(0)
         box.pack_start(hint, False, False, 0)
 
+        zoom_control = self._create_graph_zoom_control("mouse")
+        box.pack_start(zoom_control, False, False, 0)
+
         area = Gtk.DrawingArea()
         area.set_size_request(680, 320)
-        self._configure_graph_area(area, "mouse")
         area.connect("draw", self._draw_mouse_graph)
         box.pack_start(area, True, True, 0)
 

--- a/app_core/app.py
+++ b/app_core/app.py
@@ -23,7 +23,7 @@ except (ValueError, ImportError):
 gi.require_version("Gtk", "3.0")
 
 import psutil
-from gi.repository import Gtk, GLib
+from gi.repository import Gtk, GLib, Gdk
 from pynput import keyboard, mouse
 
 from .constants import (
@@ -73,6 +73,8 @@ LANGUAGE_FLAGS = {
 
 
 class SystemTrayApp:
+    GRAPH_KEYS = ('cpu', 'ram', 'swap', 'disk', 'net', 'keyboard', 'mouse')
+
     def __init__(self):
         self.settings_file = SETTINGS_FILE
         self.visibility_settings = self.load_settings()
@@ -165,6 +167,8 @@ class SystemTrayApp:
         self.mouse_graph_area: Optional[Gtk.DrawingArea] = None
         self.mouse_graph_hint_label: Optional[Gtk.Label] = None
         self.mouse_history = deque(maxlen=graph_points)
+
+        self.graph_zoom = {key: 1.0 for key in self.GRAPH_KEYS}
 
         if self.visibility_settings.get('logging_enabled', True) and not LOG_FILE.exists():
             try:
@@ -434,6 +438,54 @@ class SystemTrayApp:
         self.net_history = deque(self.net_history, maxlen=maxlen)
         self.keyboard_history = deque(self.keyboard_history, maxlen=maxlen)
         self.mouse_history = deque(self.mouse_history, maxlen=maxlen)
+
+    def _configure_graph_area(self, area: Gtk.DrawingArea, graph_key: str) -> None:
+        area.add_events(Gdk.EventMask.SCROLL_MASK)
+        area.connect("scroll-event", self._on_graph_scroll, graph_key)
+
+    def _on_graph_scroll(self, widget, event, graph_key: str):
+        if graph_key not in self.graph_zoom:
+            return False
+
+        zoom = self.graph_zoom[graph_key]
+        if event.direction == Gdk.ScrollDirection.UP:
+            zoom = min(32.0, zoom * 1.25)
+        elif event.direction == Gdk.ScrollDirection.DOWN:
+            zoom = max(1.0, zoom / 1.25)
+        elif event.direction == Gdk.ScrollDirection.SMOOTH:
+            if event.delta_y < 0:
+                zoom = min(32.0, zoom * 1.25)
+            elif event.delta_y > 0:
+                zoom = max(1.0, zoom / 1.25)
+
+        self.graph_zoom[graph_key] = zoom
+        widget.queue_draw()
+        self._refresh_graph_hints()
+        return True
+
+    def _get_zoomed_samples(self, history, graph_key: str):
+        samples = list(history)
+        zoom = max(1.0, self.graph_zoom.get(graph_key, 1.0))
+        if len(samples) <= 2 or zoom <= 1.0:
+            return samples
+        visible_points = max(2, int(len(samples) / zoom))
+        return samples[-visible_points:]
+
+    def _set_graph_hint(self, hint_label: Optional[Gtk.Label], graph_key: str, history_len: int) -> None:
+        if not hint_label:
+            return
+        zoom = self.graph_zoom.get(graph_key, 1.0)
+        visible_points = max(1, int(history_len / zoom)) if history_len > 0 else 0
+        hint_label.set_text(tr('graph_zoom_hint').format(zoom=zoom, visible=visible_points, total=history_len))
+
+    def _refresh_graph_hints(self) -> None:
+        self._set_graph_hint(self.cpu_graph_hint_label, 'cpu', len(self.cpu_history))
+        self._set_graph_hint(self.ram_graph_hint_label, 'ram', len(self.ram_history))
+        self._set_graph_hint(self.swap_graph_hint_label, 'swap', len(self.swap_history))
+        self._set_graph_hint(self.disk_graph_hint_label, 'disk', len(self.disk_history))
+        self._set_graph_hint(self.net_graph_hint_label, 'net', len(self.net_history))
+        self._set_graph_hint(self.keyboard_graph_hint_label, 'keyboard', len(self.keyboard_history))
+        self._set_graph_hint(self.mouse_graph_hint_label, 'mouse', len(self.mouse_history))
 
     def save_settings(self) -> None:
         try:
@@ -714,6 +766,7 @@ class SystemTrayApp:
 
         area = Gtk.DrawingArea()
         area.set_size_request(680, 320)
+        self._configure_graph_area(area, "cpu")
         area.connect("draw", self._draw_cpu_graph)
         box.pack_start(area, True, True, 0)
 
@@ -735,8 +788,7 @@ class SystemTrayApp:
     def _refresh_cpu_graph_texts(self) -> None:
         if self.cpu_graph_window:
             self.cpu_graph_window.set_title(f"{tr('cpu_info')} — {tr('system_status')}")
-        if self.cpu_graph_hint_label:
-            self.cpu_graph_hint_label.set_text("")
+        self._set_graph_hint(self.cpu_graph_hint_label, 'cpu', len(self.cpu_history))
         if self.cpu_graph_area:
             self.cpu_graph_area.queue_draw()
 
@@ -792,7 +844,7 @@ class SystemTrayApp:
             cr.move_to(max(2, margin_left - _text_width(text_extents) - 6), y + 4)
             cr.show_text(label)
 
-        samples = list(self.cpu_history)
+        samples = self._get_zoomed_samples(self.cpu_history, 'cpu')
         if not samples:
             self._draw_no_data(widget, cr, 'No data yet…')
             return
@@ -884,6 +936,7 @@ class SystemTrayApp:
 
         area = Gtk.DrawingArea()
         area.set_size_request(680, 320)
+        self._configure_graph_area(area, "ram")
         area.connect("draw", self._draw_ram_graph)
         box.pack_start(area, True, True, 0)
 
@@ -905,8 +958,7 @@ class SystemTrayApp:
     def _refresh_ram_graph_texts(self) -> None:
         if self.ram_graph_window:
             self.ram_graph_window.set_title(f"{tr('ram_loading')} — {tr('system_status')}")
-        if self.ram_graph_hint_label:
-            self.ram_graph_hint_label.set_text("")
+        self._set_graph_hint(self.ram_graph_hint_label, 'ram', len(self.ram_history))
         if self.ram_graph_area:
             self.ram_graph_area.queue_draw()
 
@@ -943,7 +995,7 @@ class SystemTrayApp:
             cr.move_to(max(2, margin_left - _text_width(text_extents) - 6), y + 4)
             cr.show_text(label)
 
-        samples = list(self.ram_history)
+        samples = self._get_zoomed_samples(self.ram_history, 'ram')
         if not samples:
             self._draw_no_data(widget, cr, 'No data yet…')
             return
@@ -1020,6 +1072,7 @@ class SystemTrayApp:
 
         area = Gtk.DrawingArea()
         area.set_size_request(680, 320)
+        self._configure_graph_area(area, "swap")
         area.connect("draw", self._draw_swap_graph)
         box.pack_start(area, True, True, 0)
 
@@ -1041,8 +1094,7 @@ class SystemTrayApp:
     def _refresh_swap_graph_texts(self) -> None:
         if self.swap_graph_window:
             self.swap_graph_window.set_title(f"{tr('swap_loading')} — {tr('system_status')}")
-        if self.swap_graph_hint_label:
-            self.swap_graph_hint_label.set_text("")
+        self._set_graph_hint(self.swap_graph_hint_label, 'swap', len(self.swap_history))
         if self.swap_graph_area:
             self.swap_graph_area.queue_draw()
 
@@ -1079,7 +1131,7 @@ class SystemTrayApp:
             cr.move_to(max(2, margin_left - _text_width(text_extents) - 6), y + 4)
             cr.show_text(label)
 
-        samples = list(self.swap_history)
+        samples = self._get_zoomed_samples(self.swap_history, 'swap')
         if not samples:
             self._draw_no_data(widget, cr, 'No data yet…')
             return
@@ -1156,6 +1208,7 @@ class SystemTrayApp:
 
         area = Gtk.DrawingArea()
         area.set_size_request(680, 320)
+        self._configure_graph_area(area, "disk")
         area.connect("draw", self._draw_disk_graph)
         box.pack_start(area, True, True, 0)
 
@@ -1177,8 +1230,7 @@ class SystemTrayApp:
     def _refresh_disk_graph_texts(self) -> None:
         if self.disk_graph_window:
             self.disk_graph_window.set_title(f"{tr('disk_loading')} — {tr('system_status')}")
-        if self.disk_graph_hint_label:
-            self.disk_graph_hint_label.set_text("")
+        self._set_graph_hint(self.disk_graph_hint_label, 'disk', len(self.disk_history))
         if self.disk_graph_area:
             self.disk_graph_area.queue_draw()
 
@@ -1215,7 +1267,7 @@ class SystemTrayApp:
             cr.move_to(max(2, margin_left - _text_width(text_extents) - 6), y + 4)
             cr.show_text(label)
 
-        samples = list(self.disk_history)
+        samples = self._get_zoomed_samples(self.disk_history, 'disk')
         if not samples:
             self._draw_no_data(widget, cr, 'No data yet…')
             return
@@ -1293,6 +1345,7 @@ class SystemTrayApp:
 
         area = Gtk.DrawingArea()
         area.set_size_request(680, 320)
+        self._configure_graph_area(area, "net")
         area.connect("draw", self._draw_net_graph)
         box.pack_start(area, True, True, 0)
 
@@ -1314,8 +1367,7 @@ class SystemTrayApp:
     def _refresh_net_graph_texts(self) -> None:
         if self.net_graph_window:
             self.net_graph_window.set_title(f"{tr('lan_speed')} — {tr('system_status')}")
-        if self.net_graph_hint_label:
-            self.net_graph_hint_label.set_text("")
+        self._set_graph_hint(self.net_graph_hint_label, 'net', len(self.net_history))
         if self.net_graph_area:
             self.net_graph_area.queue_draw()
 
@@ -1341,7 +1393,7 @@ class SystemTrayApp:
             cr.line_to(margin_left + plot_w, y)
         cr.stroke()
 
-        samples = list(self.net_history)
+        samples = self._get_zoomed_samples(self.net_history, 'net')
         if not samples:
             self._draw_no_data(widget, cr, 'No data yet…')
             return
@@ -1439,6 +1491,7 @@ class SystemTrayApp:
 
         area = Gtk.DrawingArea()
         area.set_size_request(680, 320)
+        self._configure_graph_area(area, "keyboard")
         area.connect("draw", self._draw_keyboard_graph)
         box.pack_start(area, True, True, 0)
 
@@ -1460,8 +1513,7 @@ class SystemTrayApp:
     def _refresh_keyboard_graph_texts(self) -> None:
         if self.keyboard_graph_window:
             self.keyboard_graph_window.set_title(f"{tr('keyboard_clicks')} — {tr('system_status')}")
-        if self.keyboard_graph_hint_label:
-            self.keyboard_graph_hint_label.set_text("")
+        self._set_graph_hint(self.keyboard_graph_hint_label, 'keyboard', len(self.keyboard_history))
         if self.keyboard_graph_area:
             self.keyboard_graph_area.queue_draw()
 
@@ -1487,7 +1539,7 @@ class SystemTrayApp:
             cr.line_to(margin_left + plot_w, y)
         cr.stroke()
 
-        samples = list(self.keyboard_history)
+        samples = self._get_zoomed_samples(self.keyboard_history, 'keyboard')
         if not samples:
             self._draw_no_data(widget, cr, 'No data yet…')
             return
@@ -1573,6 +1625,7 @@ class SystemTrayApp:
 
         area = Gtk.DrawingArea()
         area.set_size_request(680, 320)
+        self._configure_graph_area(area, "mouse")
         area.connect("draw", self._draw_mouse_graph)
         box.pack_start(area, True, True, 0)
 
@@ -1594,8 +1647,7 @@ class SystemTrayApp:
     def _refresh_mouse_graph_texts(self) -> None:
         if self.mouse_graph_window:
             self.mouse_graph_window.set_title(f"{tr('mouse_clicks')} — {tr('system_status')}")
-        if self.mouse_graph_hint_label:
-            self.mouse_graph_hint_label.set_text("")
+        self._set_graph_hint(self.mouse_graph_hint_label, 'mouse', len(self.mouse_history))
         if self.mouse_graph_area:
             self.mouse_graph_area.queue_draw()
 
@@ -1621,7 +1673,7 @@ class SystemTrayApp:
             cr.line_to(margin_left + plot_w, y)
         cr.stroke()
 
-        samples = list(self.mouse_history)
+        samples = self._get_zoomed_samples(self.mouse_history, 'mouse')
         if not samples:
             self._draw_no_data(widget, cr, 'No data yet…')
             return

--- a/app_core/app.py
+++ b/app_core/app.py
@@ -751,13 +751,13 @@ class SystemTrayApp:
         hint.set_xalign(0)
         box.pack_start(hint, False, False, 0)
 
-        zoom_control = self._create_graph_zoom_control("cpu")
-        box.pack_start(zoom_control, False, False, 0)
-
         area = Gtk.DrawingArea()
         area.set_size_request(680, 320)
         area.connect("draw", self._draw_cpu_graph)
         box.pack_start(area, True, True, 0)
+
+        zoom_control = self._create_graph_zoom_control("cpu")
+        box.pack_start(zoom_control, False, False, 0)
 
         window.add(box)
         window.connect("destroy", self._on_cpu_graph_destroy)
@@ -924,13 +924,13 @@ class SystemTrayApp:
         hint.set_xalign(0)
         box.pack_start(hint, False, False, 0)
 
-        zoom_control = self._create_graph_zoom_control("ram")
-        box.pack_start(zoom_control, False, False, 0)
-
         area = Gtk.DrawingArea()
         area.set_size_request(680, 320)
         area.connect("draw", self._draw_ram_graph)
         box.pack_start(area, True, True, 0)
+
+        zoom_control = self._create_graph_zoom_control("ram")
+        box.pack_start(zoom_control, False, False, 0)
 
         window.add(box)
         window.connect("destroy", self._on_ram_graph_destroy)
@@ -1063,13 +1063,13 @@ class SystemTrayApp:
         hint.set_xalign(0)
         box.pack_start(hint, False, False, 0)
 
-        zoom_control = self._create_graph_zoom_control("swap")
-        box.pack_start(zoom_control, False, False, 0)
-
         area = Gtk.DrawingArea()
         area.set_size_request(680, 320)
         area.connect("draw", self._draw_swap_graph)
         box.pack_start(area, True, True, 0)
+
+        zoom_control = self._create_graph_zoom_control("swap")
+        box.pack_start(zoom_control, False, False, 0)
 
         window.add(box)
         window.connect("destroy", self._on_swap_graph_destroy)
@@ -1202,13 +1202,13 @@ class SystemTrayApp:
         hint.set_xalign(0)
         box.pack_start(hint, False, False, 0)
 
-        zoom_control = self._create_graph_zoom_control("disk")
-        box.pack_start(zoom_control, False, False, 0)
-
         area = Gtk.DrawingArea()
         area.set_size_request(680, 320)
         area.connect("draw", self._draw_disk_graph)
         box.pack_start(area, True, True, 0)
+
+        zoom_control = self._create_graph_zoom_control("disk")
+        box.pack_start(zoom_control, False, False, 0)
 
         window.add(box)
         window.connect("destroy", self._on_disk_graph_destroy)
@@ -1342,13 +1342,13 @@ class SystemTrayApp:
         hint.set_xalign(0)
         box.pack_start(hint, False, False, 0)
 
-        zoom_control = self._create_graph_zoom_control("net")
-        box.pack_start(zoom_control, False, False, 0)
-
         area = Gtk.DrawingArea()
         area.set_size_request(680, 320)
         area.connect("draw", self._draw_net_graph)
         box.pack_start(area, True, True, 0)
+
+        zoom_control = self._create_graph_zoom_control("net")
+        box.pack_start(zoom_control, False, False, 0)
 
         window.add(box)
         window.connect("destroy", self._on_net_graph_destroy)
@@ -1491,13 +1491,13 @@ class SystemTrayApp:
         hint.set_xalign(0)
         box.pack_start(hint, False, False, 0)
 
-        zoom_control = self._create_graph_zoom_control("keyboard")
-        box.pack_start(zoom_control, False, False, 0)
-
         area = Gtk.DrawingArea()
         area.set_size_request(680, 320)
         area.connect("draw", self._draw_keyboard_graph)
         box.pack_start(area, True, True, 0)
+
+        zoom_control = self._create_graph_zoom_control("keyboard")
+        box.pack_start(zoom_control, False, False, 0)
 
         window.add(box)
         window.connect("destroy", self._on_keyboard_graph_destroy)
@@ -1628,13 +1628,13 @@ class SystemTrayApp:
         hint.set_xalign(0)
         box.pack_start(hint, False, False, 0)
 
-        zoom_control = self._create_graph_zoom_control("mouse")
-        box.pack_start(zoom_control, False, False, 0)
-
         area = Gtk.DrawingArea()
         area.set_size_request(680, 320)
         area.connect("draw", self._draw_mouse_graph)
         box.pack_start(area, True, True, 0)
+
+        zoom_control = self._create_graph_zoom_control("mouse")
+        box.pack_start(zoom_control, False, False, 0)
 
         window.add(box)
         window.connect("destroy", self._on_mouse_graph_destroy)

--- a/app_core/app.py
+++ b/app_core/app.py
@@ -465,7 +465,6 @@ class SystemTrayApp:
         if area:
             area.queue_draw()
 
-        self._refresh_graph_hints()
 
     def _get_zoomed_samples(self, history, graph_key: str):
         samples = list(history)
@@ -474,22 +473,6 @@ class SystemTrayApp:
             return samples
         visible_points = max(2, int(len(samples) / zoom))
         return samples[-visible_points:]
-
-    def _set_graph_hint(self, hint_label: Optional[Gtk.Label], graph_key: str, history_len: int) -> None:
-        if not hint_label:
-            return
-        zoom = self.graph_zoom.get(graph_key, 1.0)
-        visible_points = max(1, int(history_len / zoom)) if history_len > 0 else 0
-        hint_label.set_text(tr('graph_zoom_hint').format(zoom=zoom, visible=visible_points, total=history_len))
-
-    def _refresh_graph_hints(self) -> None:
-        self._set_graph_hint(self.cpu_graph_hint_label, 'cpu', len(self.cpu_history))
-        self._set_graph_hint(self.ram_graph_hint_label, 'ram', len(self.ram_history))
-        self._set_graph_hint(self.swap_graph_hint_label, 'swap', len(self.swap_history))
-        self._set_graph_hint(self.disk_graph_hint_label, 'disk', len(self.disk_history))
-        self._set_graph_hint(self.net_graph_hint_label, 'net', len(self.net_history))
-        self._set_graph_hint(self.keyboard_graph_hint_label, 'keyboard', len(self.keyboard_history))
-        self._set_graph_hint(self.mouse_graph_hint_label, 'mouse', len(self.mouse_history))
 
     def save_settings(self) -> None:
         try:
@@ -794,7 +777,8 @@ class SystemTrayApp:
     def _refresh_cpu_graph_texts(self) -> None:
         if self.cpu_graph_window:
             self.cpu_graph_window.set_title(f"{tr('cpu_info')} — {tr('system_status')}")
-        self._set_graph_hint(self.cpu_graph_hint_label, 'cpu', len(self.cpu_history))
+        if self.cpu_graph_hint_label:
+            self.cpu_graph_hint_label.set_text("")
         if self.cpu_graph_area:
             self.cpu_graph_area.queue_draw()
 
@@ -966,7 +950,8 @@ class SystemTrayApp:
     def _refresh_ram_graph_texts(self) -> None:
         if self.ram_graph_window:
             self.ram_graph_window.set_title(f"{tr('ram_loading')} — {tr('system_status')}")
-        self._set_graph_hint(self.ram_graph_hint_label, 'ram', len(self.ram_history))
+        if self.ram_graph_hint_label:
+            self.ram_graph_hint_label.set_text("")
         if self.ram_graph_area:
             self.ram_graph_area.queue_draw()
 
@@ -1104,7 +1089,8 @@ class SystemTrayApp:
     def _refresh_swap_graph_texts(self) -> None:
         if self.swap_graph_window:
             self.swap_graph_window.set_title(f"{tr('swap_loading')} — {tr('system_status')}")
-        self._set_graph_hint(self.swap_graph_hint_label, 'swap', len(self.swap_history))
+        if self.swap_graph_hint_label:
+            self.swap_graph_hint_label.set_text("")
         if self.swap_graph_area:
             self.swap_graph_area.queue_draw()
 
@@ -1242,7 +1228,8 @@ class SystemTrayApp:
     def _refresh_disk_graph_texts(self) -> None:
         if self.disk_graph_window:
             self.disk_graph_window.set_title(f"{tr('disk_loading')} — {tr('system_status')}")
-        self._set_graph_hint(self.disk_graph_hint_label, 'disk', len(self.disk_history))
+        if self.disk_graph_hint_label:
+            self.disk_graph_hint_label.set_text("")
         if self.disk_graph_area:
             self.disk_graph_area.queue_draw()
 
@@ -1381,7 +1368,8 @@ class SystemTrayApp:
     def _refresh_net_graph_texts(self) -> None:
         if self.net_graph_window:
             self.net_graph_window.set_title(f"{tr('lan_speed')} — {tr('system_status')}")
-        self._set_graph_hint(self.net_graph_hint_label, 'net', len(self.net_history))
+        if self.net_graph_hint_label:
+            self.net_graph_hint_label.set_text("")
         if self.net_graph_area:
             self.net_graph_area.queue_draw()
 
@@ -1529,7 +1517,8 @@ class SystemTrayApp:
     def _refresh_keyboard_graph_texts(self) -> None:
         if self.keyboard_graph_window:
             self.keyboard_graph_window.set_title(f"{tr('keyboard_clicks')} — {tr('system_status')}")
-        self._set_graph_hint(self.keyboard_graph_hint_label, 'keyboard', len(self.keyboard_history))
+        if self.keyboard_graph_hint_label:
+            self.keyboard_graph_hint_label.set_text("")
         if self.keyboard_graph_area:
             self.keyboard_graph_area.queue_draw()
 
@@ -1665,7 +1654,8 @@ class SystemTrayApp:
     def _refresh_mouse_graph_texts(self) -> None:
         if self.mouse_graph_window:
             self.mouse_graph_window.set_title(f"{tr('mouse_clicks')} — {tr('system_status')}")
-        self._set_graph_hint(self.mouse_graph_hint_label, 'mouse', len(self.mouse_history))
+        if self.mouse_graph_hint_label:
+            self.mouse_graph_hint_label.set_text("")
         if self.mouse_graph_area:
             self.mouse_graph_area.queue_draw()
 

--- a/app_core/language.py
+++ b/app_core/language.py
@@ -75,6 +75,7 @@ LANGUAGES = {
 
         'max_log_size_mb': 'Размер файла логов (МБ)',
         'graph_history_minutes': 'История графиков (мин.)',
+        'graph_zoom_hint': 'Zoom X: {zoom:.1f}× | Visible points: {visible}/{total} | Mouse wheel: +/-',
 
         'ping_network': 'Проверить сеть',
         'ping_running': 'Выполняется проверка сети…',
@@ -183,6 +184,7 @@ LANGUAGES = {
 
         'max_log_size_mb': 'Maximum log file size (MB)',
         'graph_history_minutes': 'Graph history (min)',
+        'graph_zoom_hint': 'Zoom X: {zoom:.1f}× | Visible points: {visible}/{total} | Mouse wheel: +/-',
 
         'ping_network': 'Ping network',
         'ping_running': 'Running network check…',
@@ -291,6 +293,7 @@ LANGUAGES = {
 
         'max_log_size_mb': '日志文件的最大大小 (MB)',
         'graph_history_minutes': '图表历史记录（分钟）',
+        'graph_zoom_hint': 'Zoom X: {zoom:.1f}× | Visible points: {visible}/{total} | Mouse wheel: +/-',
 
         'ping_network': '网络连通性测试（ping）',
         'ping_running': '正在进行网络测试…',
@@ -399,6 +402,7 @@ LANGUAGES = {
 
         'max_log_size_mb': 'Maximale Protokolldateigröße (MB)',
         'graph_history_minutes': 'Diagrammverlauf (Min.)',
+        'graph_zoom_hint': 'Zoom X: {zoom:.1f}× | Visible points: {visible}/{total} | Mouse wheel: +/-',
 
         'ping_network': 'Netzwerk prüfen (Ping)',
         'show_ping': 'Ping-Schaltfläche im Tray anzeigen',
@@ -508,6 +512,7 @@ LANGUAGES = {
 
         'max_log_size_mb': 'Dimensione massima del file di log (MB)',
         'graph_history_minutes': 'Cronologia grafici (min)',
+        'graph_zoom_hint': 'Zoom X: {zoom:.1f}× | Visible points: {visible}/{total} | Mouse wheel: +/-',
 
         'ping_network': 'Verifica rete (ping)',
         'ping_running': 'Verifica della rete in corso…',
@@ -616,6 +621,7 @@ LANGUAGES = {
 
         'max_log_size_mb': 'Tamaño máximo del archivo de registro (MB)',
         'graph_history_minutes': 'Historial de gráficos (min)',
+        'graph_zoom_hint': 'Zoom X: {zoom:.1f}× | Visible points: {visible}/{total} | Mouse wheel: +/-',
 
         'ping_network': 'Probar red (ping)',
         'ping_running': 'Comprobando la red…',
@@ -724,6 +730,7 @@ LANGUAGES = {
 
         'max_log_size_mb': 'Maksimum günlük dosyası boyutu (MB)',
         'graph_history_minutes': 'Grafik geçmişi (dk.)',
+        'graph_zoom_hint': 'Zoom X: {zoom:.1f}× | Visible points: {visible}/{total} | Mouse wheel: +/-',
 
         'ping_network': 'Ağı kontrol et (ping)',
         'ping_running': 'Ağ kontrolü yapılıyor…',
@@ -832,6 +839,7 @@ LANGUAGES = {
 
         'max_log_size_mb': 'Taille maximale du fichier journal (Mo)',
         'graph_history_minutes': 'Historique des graphiques (min)',
+        'graph_zoom_hint': 'Zoom X: {zoom:.1f}× | Visible points: {visible}/{total} | Mouse wheel: +/-',
 
         'ping_network': 'Vérifier le réseau (ping)',
         'ping_running': 'Vérification du réseau en cours…',

--- a/app_core/language.py
+++ b/app_core/language.py
@@ -75,8 +75,7 @@ LANGUAGES = {
 
         'max_log_size_mb': 'Размер файла логов (МБ)',
         'graph_history_minutes': 'История графиков (мин.)',
-        'graph_zoom_label': 'Масштаб по X:',
-        'graph_zoom_hint': 'Zoom X: {zoom:.1f}× | Visible points: {visible}/{total} | Slider: 1.0–32.0',
+        'graph_zoom_label': 'Масштаб:',
 
         'ping_network': 'Проверить сеть',
         'ping_running': 'Выполняется проверка сети…',
@@ -185,8 +184,7 @@ LANGUAGES = {
 
         'max_log_size_mb': 'Maximum log file size (MB)',
         'graph_history_minutes': 'Graph history (min)',
-        'graph_zoom_label': 'X-axis zoom:',
-        'graph_zoom_hint': 'Zoom X: {zoom:.1f}× | Visible points: {visible}/{total} | Slider: 1.0–32.0',
+        'graph_zoom_label': 'Масштаб:',
 
         'ping_network': 'Ping network',
         'ping_running': 'Running network check…',
@@ -295,8 +293,7 @@ LANGUAGES = {
 
         'max_log_size_mb': '日志文件的最大大小 (MB)',
         'graph_history_minutes': '图表历史记录（分钟）',
-        'graph_zoom_label': 'X轴缩放：',
-        'graph_zoom_hint': 'Zoom X: {zoom:.1f}× | Visible points: {visible}/{total} | Slider: 1.0–32.0',
+        'graph_zoom_label': 'Масштаб:',
 
         'ping_network': '网络连通性测试（ping）',
         'ping_running': '正在进行网络测试…',
@@ -405,8 +402,7 @@ LANGUAGES = {
 
         'max_log_size_mb': 'Maximale Protokolldateigröße (MB)',
         'graph_history_minutes': 'Diagrammverlauf (Min.)',
-        'graph_zoom_label': 'X-Achsen-Zoom:',
-        'graph_zoom_hint': 'Zoom X: {zoom:.1f}× | Visible points: {visible}/{total} | Slider: 1.0–32.0',
+        'graph_zoom_label': 'Масштаб:',
 
         'ping_network': 'Netzwerk prüfen (Ping)',
         'show_ping': 'Ping-Schaltfläche im Tray anzeigen',
@@ -516,8 +512,7 @@ LANGUAGES = {
 
         'max_log_size_mb': 'Dimensione massima del file di log (MB)',
         'graph_history_minutes': 'Cronologia grafici (min)',
-        'graph_zoom_label': 'Zoom asse X:',
-        'graph_zoom_hint': 'Zoom X: {zoom:.1f}× | Visible points: {visible}/{total} | Slider: 1.0–32.0',
+        'graph_zoom_label': 'Масштаб:',
 
         'ping_network': 'Verifica rete (ping)',
         'ping_running': 'Verifica della rete in corso…',
@@ -626,8 +621,7 @@ LANGUAGES = {
 
         'max_log_size_mb': 'Tamaño máximo del archivo de registro (MB)',
         'graph_history_minutes': 'Historial de gráficos (min)',
-        'graph_zoom_label': 'Zoom eje X:',
-        'graph_zoom_hint': 'Zoom X: {zoom:.1f}× | Visible points: {visible}/{total} | Slider: 1.0–32.0',
+        'graph_zoom_label': 'Масштаб:',
 
         'ping_network': 'Probar red (ping)',
         'ping_running': 'Comprobando la red…',
@@ -736,8 +730,7 @@ LANGUAGES = {
 
         'max_log_size_mb': 'Maksimum günlük dosyası boyutu (MB)',
         'graph_history_minutes': 'Grafik geçmişi (dk.)',
-        'graph_zoom_label': 'X ekseni yakınlaştırma:',
-        'graph_zoom_hint': 'Zoom X: {zoom:.1f}× | Visible points: {visible}/{total} | Slider: 1.0–32.0',
+        'graph_zoom_label': 'Масштаб:',
 
         'ping_network': 'Ağı kontrol et (ping)',
         'ping_running': 'Ağ kontrolü yapılıyor…',
@@ -846,8 +839,7 @@ LANGUAGES = {
 
         'max_log_size_mb': 'Taille maximale du fichier journal (Mo)',
         'graph_history_minutes': 'Historique des graphiques (min)',
-        'graph_zoom_label': 'Zoom axe X :',
-        'graph_zoom_hint': 'Zoom X: {zoom:.1f}× | Visible points: {visible}/{total} | Slider: 1.0–32.0',
+        'graph_zoom_label': 'Масштаб:',
 
         'ping_network': 'Vérifier le réseau (ping)',
         'ping_running': 'Vérification du réseau en cours…',

--- a/app_core/language.py
+++ b/app_core/language.py
@@ -75,7 +75,8 @@ LANGUAGES = {
 
         'max_log_size_mb': 'Размер файла логов (МБ)',
         'graph_history_minutes': 'История графиков (мин.)',
-        'graph_zoom_hint': 'Zoom X: {zoom:.1f}× | Visible points: {visible}/{total} | Mouse wheel: +/-',
+        'graph_zoom_label': 'Масштаб по X:',
+        'graph_zoom_hint': 'Zoom X: {zoom:.1f}× | Visible points: {visible}/{total} | Slider: 1.0–32.0',
 
         'ping_network': 'Проверить сеть',
         'ping_running': 'Выполняется проверка сети…',
@@ -184,7 +185,8 @@ LANGUAGES = {
 
         'max_log_size_mb': 'Maximum log file size (MB)',
         'graph_history_minutes': 'Graph history (min)',
-        'graph_zoom_hint': 'Zoom X: {zoom:.1f}× | Visible points: {visible}/{total} | Mouse wheel: +/-',
+        'graph_zoom_label': 'X-axis zoom:',
+        'graph_zoom_hint': 'Zoom X: {zoom:.1f}× | Visible points: {visible}/{total} | Slider: 1.0–32.0',
 
         'ping_network': 'Ping network',
         'ping_running': 'Running network check…',
@@ -293,7 +295,8 @@ LANGUAGES = {
 
         'max_log_size_mb': '日志文件的最大大小 (MB)',
         'graph_history_minutes': '图表历史记录（分钟）',
-        'graph_zoom_hint': 'Zoom X: {zoom:.1f}× | Visible points: {visible}/{total} | Mouse wheel: +/-',
+        'graph_zoom_label': 'X轴缩放：',
+        'graph_zoom_hint': 'Zoom X: {zoom:.1f}× | Visible points: {visible}/{total} | Slider: 1.0–32.0',
 
         'ping_network': '网络连通性测试（ping）',
         'ping_running': '正在进行网络测试…',
@@ -402,7 +405,8 @@ LANGUAGES = {
 
         'max_log_size_mb': 'Maximale Protokolldateigröße (MB)',
         'graph_history_minutes': 'Diagrammverlauf (Min.)',
-        'graph_zoom_hint': 'Zoom X: {zoom:.1f}× | Visible points: {visible}/{total} | Mouse wheel: +/-',
+        'graph_zoom_label': 'X-Achsen-Zoom:',
+        'graph_zoom_hint': 'Zoom X: {zoom:.1f}× | Visible points: {visible}/{total} | Slider: 1.0–32.0',
 
         'ping_network': 'Netzwerk prüfen (Ping)',
         'show_ping': 'Ping-Schaltfläche im Tray anzeigen',
@@ -512,7 +516,8 @@ LANGUAGES = {
 
         'max_log_size_mb': 'Dimensione massima del file di log (MB)',
         'graph_history_minutes': 'Cronologia grafici (min)',
-        'graph_zoom_hint': 'Zoom X: {zoom:.1f}× | Visible points: {visible}/{total} | Mouse wheel: +/-',
+        'graph_zoom_label': 'Zoom asse X:',
+        'graph_zoom_hint': 'Zoom X: {zoom:.1f}× | Visible points: {visible}/{total} | Slider: 1.0–32.0',
 
         'ping_network': 'Verifica rete (ping)',
         'ping_running': 'Verifica della rete in corso…',
@@ -621,7 +626,8 @@ LANGUAGES = {
 
         'max_log_size_mb': 'Tamaño máximo del archivo de registro (MB)',
         'graph_history_minutes': 'Historial de gráficos (min)',
-        'graph_zoom_hint': 'Zoom X: {zoom:.1f}× | Visible points: {visible}/{total} | Mouse wheel: +/-',
+        'graph_zoom_label': 'Zoom eje X:',
+        'graph_zoom_hint': 'Zoom X: {zoom:.1f}× | Visible points: {visible}/{total} | Slider: 1.0–32.0',
 
         'ping_network': 'Probar red (ping)',
         'ping_running': 'Comprobando la red…',
@@ -730,7 +736,8 @@ LANGUAGES = {
 
         'max_log_size_mb': 'Maksimum günlük dosyası boyutu (MB)',
         'graph_history_minutes': 'Grafik geçmişi (dk.)',
-        'graph_zoom_hint': 'Zoom X: {zoom:.1f}× | Visible points: {visible}/{total} | Mouse wheel: +/-',
+        'graph_zoom_label': 'X ekseni yakınlaştırma:',
+        'graph_zoom_hint': 'Zoom X: {zoom:.1f}× | Visible points: {visible}/{total} | Slider: 1.0–32.0',
 
         'ping_network': 'Ağı kontrol et (ping)',
         'ping_running': 'Ağ kontrolü yapılıyor…',
@@ -839,7 +846,8 @@ LANGUAGES = {
 
         'max_log_size_mb': 'Taille maximale du fichier journal (Mo)',
         'graph_history_minutes': 'Historique des graphiques (min)',
-        'graph_zoom_hint': 'Zoom X: {zoom:.1f}× | Visible points: {visible}/{total} | Mouse wheel: +/-',
+        'graph_zoom_label': 'Zoom axe X :',
+        'graph_zoom_hint': 'Zoom X: {zoom:.1f}× | Visible points: {visible}/{total} | Slider: 1.0–32.0',
 
         'ping_network': 'Vérifier le réseau (ping)',
         'ping_running': 'Vérification du réseau en cours…',


### PR DESCRIPTION
### Motivation
- Enable horizontal scaling (X-axis zoom) on all monitoring charts so users can inspect historical data at different resolutions using the mouse wheel.
- Provide an on-chart hint with current zoom and visible points so users understand the zoom level and interaction.

### Description
- Added `Gdk` import and `GRAPH_KEYS` plus a `graph_zoom` store to track per-chart zoom factors and limits.
- Implemented `_configure_graph_area`, `_on_graph_scroll`, `_get_zoomed_samples`, `_set_graph_hint`, and `_refresh_graph_hints` to handle scroll events, update zoom, pick the visible subset of samples, and update hint labels.
- Wired scroll handling into every `Gtk.DrawingArea` for CPU, RAM, Swap, Disk, Network, Keyboard and Mouse by calling `self._configure_graph_area(area, "<key>")` and switched draw routines to use `self._get_zoomed_samples(...)` instead of the full history.
- Replaced empty hint updates with `self._set_graph_hint(...)` and added a new localization key `graph_zoom_hint` across language dictionaries for the hint text.

### Testing
- Ran `python -m py_compile app_core/app.py app_core/language.py` which completed successfully.
- Ran `pytest -q` and all tests passed: `20 passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b84148451083269d3f06265cfe653c)