### PR TITLE
Добавить масштабирование графиков по горизонтали колесом мыши

### DIFF
--- a/app_core/app.py
+++ b/app_core/app.py
@@ -23,7 +23,7 @@ except (ValueError, ImportError):
 gi.require_version("Gtk", "3.0")
 
 import psutil
-from gi.repository import Gtk, GLib
+from gi.repository import Gtk, GLib, Gdk
 from pynput import keyboard, mouse
 
 from .constants import (
@@ -165,6 +165,16 @@ class SystemTrayApp:
         self.mouse_graph_area: Optional[Gtk.DrawingArea] = None
         self.mouse_graph_hint_label: Optional[Gtk.Label] = None
         self.mouse_history = deque(maxlen=graph_points)
+
+        self.graph_zoom_state: Dict[str, Dict[str, float]] = {
+            'cpu': {'scale': 1.0, 'center': 1.0},
+            'ram': {'scale': 1.0, 'center': 1.0},
+            'swap': {'scale': 1.0, 'center': 1.0},
+            'disk': {'scale': 1.0, 'center': 1.0},
+            'net': {'scale': 1.0, 'center': 1.0},
+            'keyboard': {'scale': 1.0, 'center': 1.0},
+            'mouse': {'scale': 1.0, 'center': 1.0},
+        }
 
         if self.visibility_settings.get('logging_enabled', True) and not LOG_FILE.exists():
             try:
@@ -715,6 +725,7 @@ class SystemTrayApp:
         area = Gtk.DrawingArea()
         area.set_size_request(680, 320)
         area.connect("draw", self._draw_cpu_graph)
+        self._connect_graph_zoom(area, 'cpu')
         box.pack_start(area, True, True, 0)
 
         window.add(box)
@@ -736,7 +747,7 @@ class SystemTrayApp:
         if self.cpu_graph_window:
             self.cpu_graph_window.set_title(f"{tr('cpu_info')} — {tr('system_status')}")
         if self.cpu_graph_hint_label:
-            self.cpu_graph_hint_label.set_text("")
+            self.cpu_graph_hint_label.set_text(self._zoom_hint_text())
         if self.cpu_graph_area:
             self.cpu_graph_area.queue_draw()
 
@@ -757,6 +768,77 @@ class SystemTrayApp:
         y = max(20, height / 2)
         cr.move_to(x, y)
         cr.show_text(message)
+
+    @staticmethod
+    def _clamp(value: float, min_value: float, max_value: float) -> float:
+        return max(min_value, min(max_value, value))
+
+    def _zoom_hint_text(self) -> str:
+        return "Колесо мыши: масштаб по горизонтали (точка под курсором)"
+
+    def _visible_samples(self, graph_key: str, samples: list[tuple]) -> list[tuple]:
+        if len(samples) <= 2:
+            return samples
+        state = self.graph_zoom_state.get(graph_key)
+        if not state:
+            return samples
+
+        scale = self._clamp(float(state.get('scale', 1.0)), 1.0, 40.0)
+        if scale <= 1.0:
+            return samples
+
+        total = len(samples)
+        window_len = max(2, int(round(total / scale)))
+        center = self._clamp(float(state.get('center', 1.0)), 0.0, 1.0)
+        center_idx = int(round(center * (total - 1)))
+
+        start = center_idx - (window_len // 2)
+        max_start = max(0, total - window_len)
+        start = min(max(0, start), max_start)
+        end = start + window_len
+        return samples[start:end]
+
+    def _connect_graph_zoom(self, area: Gtk.DrawingArea, graph_key: str) -> None:
+        area.set_events(area.get_events() | Gdk.EventMask.SCROLL_MASK)
+        area.connect('scroll-event', self._on_graph_scroll_event, graph_key)
+
+    def _on_graph_scroll_event(self, widget, event, graph_key: str):
+        state = self.graph_zoom_state.get(graph_key)
+        if state is None:
+            return False
+
+        width = max(1, widget.get_allocated_width())
+        anchor_x = self._clamp(float(getattr(event, 'x', width / 2)), 0.0, float(width))
+        anchor_ratio = anchor_x / width
+
+        old_scale = self._clamp(float(state.get('scale', 1.0)), 1.0, 40.0)
+        zoom_factor = 1.0
+        if event.direction == Gdk.ScrollDirection.UP:
+            zoom_factor = 1.2
+        elif event.direction == Gdk.ScrollDirection.DOWN:
+            zoom_factor = 1 / 1.2
+        elif event.direction == Gdk.ScrollDirection.SMOOTH:
+            delta_y = float(getattr(event, 'delta_y', 0.0))
+            zoom_factor = 1.2 if delta_y < 0 else (1 / 1.2 if delta_y > 0 else 1.0)
+
+        if zoom_factor == 1.0:
+            return False
+
+        new_scale = self._clamp(old_scale * zoom_factor, 1.0, 40.0)
+        old_span = 1.0 / old_scale
+        new_span = 1.0 / new_scale
+        old_center = self._clamp(float(state.get('center', 1.0)), 0.0, 1.0)
+        old_left = self._clamp(old_center - old_span / 2, 0.0, max(0.0, 1.0 - old_span))
+        anchor_global = old_left + anchor_ratio * old_span
+
+        new_left = anchor_global - anchor_ratio * new_span
+        new_left = self._clamp(new_left, 0.0, max(0.0, 1.0 - new_span))
+        new_center = new_left + new_span / 2
+
+        state['scale'] = new_scale
+        state['center'] = self._clamp(new_center, 0.0, 1.0)
+        widget.queue_draw()
+        return True
 
     def _draw_cpu_graph(self, widget, cr):
         width = widget.get_allocated_width()
@@ -792,7 +874,7 @@ class SystemTrayApp:
             cr.move_to(max(2, margin_left - _text_width(text_extents) - 6), y + 4)
             cr.show_text(label)
 
-        samples = list(self.cpu_history)
+        samples = self._visible_samples('cpu', list(self.cpu_history))
         if not samples:
             self._draw_no_data(widget, cr, 'No data yet…')
             return
@@ -885,6 +967,7 @@ class SystemTrayApp:
         area = Gtk.DrawingArea()
         area.set_size_request(680, 320)
         area.connect("draw", self._draw_ram_graph)
+        self._connect_graph_zoom(area, 'ram')
         box.pack_start(area, True, True, 0)
 
         window.add(box)
@@ -906,7 +989,7 @@ class SystemTrayApp:
         if self.ram_graph_window:
             self.ram_graph_window.set_title(f"{tr('ram_loading')} — {tr('system_status')}")
         if self.ram_graph_hint_label:
-            self.ram_graph_hint_label.set_text("")
+            self.ram_graph_hint_label.set_text(self._zoom_hint_text())
         if self.ram_graph_area:
             self.ram_graph_area.queue_draw()
 
@@ -943,7 +1026,7 @@ class SystemTrayApp:
             cr.move_to(max(2, margin_left - _text_width(text_extents) - 6), y + 4)
             cr.show_text(label)
 
-        samples = list(self.ram_history)
+        samples = self._visible_samples('ram', list(self.ram_history))
         if not samples:
             self._draw_no_data(widget, cr, 'No data yet…')
             return
@@ -1021,6 +1104,7 @@ class SystemTrayApp:
         area = Gtk.DrawingArea()
         area.set_size_request(680, 320)
         area.connect("draw", self._draw_swap_graph)
+        self._connect_graph_zoom(area, 'swap')
         box.pack_start(area, True, True, 0)
 
         window.add(box)
@@ -1042,7 +1126,7 @@ class SystemTrayApp:
         if self.swap_graph_window:
             self.swap_graph_window.set_title(f"{tr('swap_loading')} — {tr('system_status')}")
         if self.swap_graph_hint_label:
-            self.swap_graph_hint_label.set_text("")
+            self.swap_graph_hint_label.set_text(self._zoom_hint_text())
         if self.swap_graph_area:
             self.swap_graph_area.queue_draw()
 
@@ -1079,7 +1163,7 @@ class SystemTrayApp:
             cr.move_to(max(2, margin_left - _text_width(text_extents) - 6), y + 4)
             cr.show_text(label)
 
-        samples = list(self.swap_history)
+        samples = self._visible_samples('swap', list(self.swap_history))
         if not samples:
             self._draw_no_data(widget, cr, 'No data yet…')
             return
@@ -1157,6 +1241,7 @@ class SystemTrayApp:
         area = Gtk.DrawingArea()
         area.set_size_request(680, 320)
         area.connect("draw", self._draw_disk_graph)
+        self._connect_graph_zoom(area, 'disk')
         box.pack_start(area, True, True, 0)
 
         window.add(box)
@@ -1178,7 +1263,7 @@ class SystemTrayApp:
         if self.disk_graph_window:
             self.disk_graph_window.set_title(f"{tr('disk_loading')} — {tr('system_status')}")
         if self.disk_graph_hint_label:
-            self.disk_graph_hint_label.set_text("")
+            self.disk_graph_hint_label.set_text(self._zoom_hint_text())
         if self.disk_graph_area:
             self.disk_graph_area.queue_draw()
 
@@ -1215,7 +1300,7 @@ class SystemTrayApp:
             cr.move_to(max(2, margin_left - _text_width(text_extents) - 6), y + 4)
             cr.show_text(label)
 
-        samples = list(self.disk_history)
+        samples = self._visible_samples('disk', list(self.disk_history))
         if not samples:
             self._draw_no_data(widget, cr, 'No data yet…')
             return
@@ -1294,6 +1379,7 @@ class SystemTrayApp:
         area = Gtk.DrawingArea()
         area.set_size_request(680, 320)
         area.connect("draw", self._draw_net_graph)
+        self._connect_graph_zoom(area, 'net')
         box.pack_start(area, True, True, 0)
 
         window.add(box)
@@ -1315,7 +1401,7 @@ class SystemTrayApp:
         if self.net_graph_window:
             self.net_graph_window.set_title(f"{tr('lan_speed')} — {tr('system_status')}")
         if self.net_graph_hint_label:
-            self.net_graph_hint_label.set_text("")
+            self.net_graph_hint_label.set_text(self._zoom_hint_text())
         if self.net_graph_area:
             self.net_graph_area.queue_draw()
 
@@ -1341,7 +1427,7 @@ class SystemTrayApp:
             cr.line_to(margin_left + plot_w, y)
         cr.stroke()
 
-        samples = list(self.net_history)
+        samples = self._visible_samples('net', list(self.net_history))
         if not samples:
             self._draw_no_data(widget, cr, 'No data yet…')
             return
@@ -1440,6 +1526,7 @@ class SystemTrayApp:
         area = Gtk.DrawingArea()
         area.set_size_request(680, 320)
         area.connect("draw", self._draw_keyboard_graph)
+        self._connect_graph_zoom(area, 'keyboard')
         box.pack_start(area, True, True, 0)
 
         window.add(box)
@@ -1461,7 +1548,7 @@ class SystemTrayApp:
         if self.keyboard_graph_window:
             self.keyboard_graph_window.set_title(f"{tr('keyboard_clicks')} — {tr('system_status')}")
         if self.keyboard_graph_hint_label:
-            self.keyboard_graph_hint_label.set_text("")
+            self.keyboard_graph_hint_label.set_text(self._zoom_hint_text())
         if self.keyboard_graph_area:
             self.keyboard_graph_area.queue_draw()
 
@@ -1487,7 +1574,7 @@ class SystemTrayApp:
             cr.line_to(margin_left + plot_w, y)
         cr.stroke()
 
-        samples = list(self.keyboard_history)
+        samples = self._visible_samples('keyboard', list(self.keyboard_history))
         if not samples:
             self._draw_no_data(widget, cr, 'No data yet…')
             return
@@ -1574,6 +1661,7 @@ class SystemTrayApp:
         area = Gtk.DrawingArea()
         area.set_size_request(680, 320)
         area.connect("draw", self._draw_mouse_graph)
+        self._connect_graph_zoom(area, 'mouse')
         box.pack_start(area, True, True, 0)
 
         window.add(box)
@@ -1595,7 +1683,7 @@ class SystemTrayApp:
         if self.mouse_graph_window:
             self.mouse_graph_window.set_title(f"{tr('mouse_clicks')} — {tr('system_status')}")
         if self.mouse_graph_hint_label:
-            self.mouse_graph_hint_label.set_text("")
+            self.mouse_graph_hint_label.set_text(self._zoom_hint_text())
         if self.mouse_graph_area:
             self.mouse_graph_area.queue_draw()
 
@@ -1621,7 +1709,7 @@ class SystemTrayApp:
             cr.line_to(margin_left + plot_w, y)
         cr.stroke()
 
-        samples = list(self.mouse_history)
+        samples = self._visible_samples('mouse', list(self.mouse_history))
         if not samples:
             self._draw_no_data(widget, cr, 'No data yet…')
             return

--- a/app_core/app.py
+++ b/app_core/app.py
@@ -9,7 +9,7 @@ import subprocess
 import threading
 import time
 from pathlib import Path
-from typing import Dict, Optional
+from typing import Callable, Dict, Optional
 
 import gi
 
@@ -167,13 +167,13 @@ class SystemTrayApp:
         self.mouse_history = deque(maxlen=graph_points)
 
         self.graph_zoom_state: Dict[str, Dict[str, float]] = {
-            'cpu': {'scale': 1.0, 'center': 1.0, 'dragging': 0.0, 'last_x': 0.0},
-            'ram': {'scale': 1.0, 'center': 1.0, 'dragging': 0.0, 'last_x': 0.0},
-            'swap': {'scale': 1.0, 'center': 1.0, 'dragging': 0.0, 'last_x': 0.0},
-            'disk': {'scale': 1.0, 'center': 1.0, 'dragging': 0.0, 'last_x': 0.0},
-            'net': {'scale': 1.0, 'center': 1.0, 'dragging': 0.0, 'last_x': 0.0},
-            'keyboard': {'scale': 1.0, 'center': 1.0, 'dragging': 0.0, 'last_x': 0.0},
-            'mouse': {'scale': 1.0, 'center': 1.0, 'dragging': 0.0, 'last_x': 0.0},
+            'cpu': {'scale': 1.0, 'center': 1.0, 'dragging': 0.0, 'last_x': 0.0, 'hovering': 0.0, 'hover_x': 0.0, 'hover_y': 0.0},
+            'ram': {'scale': 1.0, 'center': 1.0, 'dragging': 0.0, 'last_x': 0.0, 'hovering': 0.0, 'hover_x': 0.0, 'hover_y': 0.0},
+            'swap': {'scale': 1.0, 'center': 1.0, 'dragging': 0.0, 'last_x': 0.0, 'hovering': 0.0, 'hover_x': 0.0, 'hover_y': 0.0},
+            'disk': {'scale': 1.0, 'center': 1.0, 'dragging': 0.0, 'last_x': 0.0, 'hovering': 0.0, 'hover_x': 0.0, 'hover_y': 0.0},
+            'net': {'scale': 1.0, 'center': 1.0, 'dragging': 0.0, 'last_x': 0.0, 'hovering': 0.0, 'hover_x': 0.0, 'hover_y': 0.0},
+            'keyboard': {'scale': 1.0, 'center': 1.0, 'dragging': 0.0, 'last_x': 0.0, 'hovering': 0.0, 'hover_x': 0.0, 'hover_y': 0.0},
+            'mouse': {'scale': 1.0, 'center': 1.0, 'dragging': 0.0, 'last_x': 0.0, 'hovering': 0.0, 'hover_x': 0.0, 'hover_y': 0.0},
         }
 
         if self.visibility_settings.get('logging_enabled', True) and not LOG_FILE.exists():
@@ -803,11 +803,13 @@ class SystemTrayApp:
             | Gdk.EventMask.BUTTON_RELEASE_MASK
             | Gdk.EventMask.POINTER_MOTION_MASK
             | Gdk.EventMask.BUTTON1_MOTION_MASK
+            | Gdk.EventMask.LEAVE_NOTIFY_MASK
         )
         area.connect('scroll-event', self._on_graph_scroll_event, graph_key)
         area.connect('button-press-event', self._on_graph_button_press_event, graph_key)
         area.connect('motion-notify-event', self._on_graph_motion_notify_event, graph_key)
         area.connect('button-release-event', self._on_graph_button_release_event, graph_key)
+        area.connect('leave-notify-event', self._on_graph_leave_notify_event, graph_key)
 
     def _on_graph_scroll_event(self, widget, event, graph_key: str):
         state = self.graph_zoom_state.get(graph_key)
@@ -859,7 +861,15 @@ class SystemTrayApp:
 
     def _on_graph_motion_notify_event(self, widget, event, graph_key: str):
         state = self.graph_zoom_state.get(graph_key)
-        if state is None or state.get('dragging', 0.0) < 0.5:
+        if state is None:
+            return False
+
+        state['hovering'] = 1.0
+        state['hover_x'] = float(getattr(event, 'x', 0.0))
+        state['hover_y'] = float(getattr(event, 'y', 0.0))
+
+        if state.get('dragging', 0.0) < 0.5:
+            widget.queue_draw()
             return False
 
         width = max(1, widget.get_allocated_width())
@@ -888,6 +898,82 @@ class SystemTrayApp:
             return False
         state['dragging'] = 0.0
         return True
+
+    def _on_graph_leave_notify_event(self, widget, _event, graph_key: str):
+        state = self.graph_zoom_state.get(graph_key)
+        if state is None:
+            return False
+        state['hovering'] = 0.0
+        widget.queue_draw()
+        return False
+
+    def _draw_graph_hover_info(self,
+                              widget,
+                              cr,
+                              graph_key: str,
+                              samples: list[tuple],
+                              margin_left: float,
+                              margin_top: float,
+                              plot_w: float,
+                              plot_h: float,
+                              formatter: Callable[[tuple], list[str]]) -> None:
+        state = self.graph_zoom_state.get(graph_key)
+        if not state or state.get('hovering', 0.0) < 0.5 or not samples:
+            return
+
+        width = widget.get_allocated_width()
+        height = widget.get_allocated_height()
+        hover_x = self._clamp(float(state.get('hover_x', 0.0)), 0.0, float(width))
+        hover_y = self._clamp(float(state.get('hover_y', 0.0)), 0.0, float(height))
+
+        left = margin_left
+        right = margin_left + plot_w
+        top = margin_top
+        bottom = margin_top + plot_h
+        if hover_x < left or hover_x > right or hover_y < top or hover_y > bottom:
+            return
+
+        if len(samples) <= 1:
+            idx = 0
+            point_x = left
+        else:
+            ratio = self._clamp((hover_x - left) / max(1.0, plot_w), 0.0, 1.0)
+            idx = int(round(ratio * (len(samples) - 1)))
+            idx = max(0, min(len(samples) - 1, idx))
+            point_x = left + plot_w * idx / (len(samples) - 1)
+
+        sample = samples[idx]
+        lines = formatter(sample)
+        if not lines:
+            return
+
+        cr.set_source_rgba(1.0, 1.0, 1.0, 0.22)
+        cr.set_line_width(1)
+        cr.move_to(point_x, top)
+        cr.line_to(point_x, bottom)
+        cr.stroke()
+
+        cr.select_font_face("Sans", 0, 0)
+        cr.set_font_size(11)
+        padding = 6
+        line_height = 14
+        max_w = 0.0
+        for line in lines:
+            max_w = max(max_w, _text_width(cr.text_extents(line)))
+
+        box_w = max_w + padding * 2
+        box_h = line_height * len(lines) + padding * 2
+        box_x = self._clamp(hover_x + 12, 4.0, max(4.0, width - box_w - 4))
+        box_y = self._clamp(hover_y + 12, 4.0, max(4.0, height - box_h - 4))
+
+        cr.set_source_rgba(0.05, 0.05, 0.05, 0.88)
+        cr.rectangle(box_x, box_y, box_w, box_h)
+        cr.fill()
+
+        cr.set_source_rgb(0.96, 0.96, 0.96)
+        for i, line in enumerate(lines):
+            cr.move_to(box_x + padding, box_y + padding + line_height * (i + 1) - 3)
+            cr.show_text(line)
 
     def _draw_cpu_graph(self, widget, cr):
         width = widget.get_allocated_width()
@@ -974,6 +1060,22 @@ class SystemTrayApp:
         ext = cr.text_extents(values_text)
         cr.move_to(width - margin_right - _text_width(ext), 12)
         cr.show_text(values_text)
+
+        self._draw_graph_hover_info(
+            widget,
+            cr,
+            'cpu',
+            samples,
+            margin_left,
+            margin_top,
+            plot_w,
+            plot_h,
+            lambda sample: [
+                datetime.fromtimestamp(sample[0]).strftime("%H:%M:%S"),
+                f"{tr('cpu')}: {sample[1]:.1f}%",
+                f"{tr('temperature')}: {sample[2]:.1f}°C",
+            ],
+        )
 
         # Start and end time at the bottom
         start_ts = datetime.fromtimestamp(samples[0][0]).strftime("%H:%M:%S")
@@ -1113,6 +1215,22 @@ class SystemTrayApp:
         cr.move_to(width - margin_right - _text_width(ext), 12)
         cr.show_text(values_text)
 
+        self._draw_graph_hover_info(
+            widget,
+            cr,
+            'ram',
+            samples,
+            margin_left,
+            margin_top,
+            plot_w,
+            plot_h,
+            lambda sample: [
+                datetime.fromtimestamp(sample[0]).strftime("%H:%M:%S"),
+                f"{tr('ram_loading')}: {sample[3]:.1f}%",
+                f"{sample[1]:.1f}/{sample[2]:.1f} GB",
+            ],
+        )
+
         start_ts = datetime.fromtimestamp(samples[0][0]).strftime("%H:%M:%S")
         end_ts = datetime.fromtimestamp(samples[-1][0]).strftime("%H:%M:%S")
 
@@ -1250,6 +1368,22 @@ class SystemTrayApp:
         cr.move_to(width - margin_right - _text_width(ext), 12)
         cr.show_text(values_text)
 
+        self._draw_graph_hover_info(
+            widget,
+            cr,
+            'swap',
+            samples,
+            margin_left,
+            margin_top,
+            plot_w,
+            plot_h,
+            lambda sample: [
+                datetime.fromtimestamp(sample[0]).strftime("%H:%M:%S"),
+                f"{tr('swap_loading')}: {sample[3]:.1f}%",
+                f"{sample[1]:.1f}/{sample[2]:.1f} GB",
+            ],
+        )
+
         start_ts = datetime.fromtimestamp(samples[0][0]).strftime("%H:%M:%S")
         end_ts = datetime.fromtimestamp(samples[-1][0]).strftime("%H:%M:%S")
 
@@ -1386,6 +1520,22 @@ class SystemTrayApp:
         ext = cr.text_extents(values_text)
         cr.move_to(width - margin_right - _text_width(ext), 12)
         cr.show_text(values_text)
+
+        self._draw_graph_hover_info(
+            widget,
+            cr,
+            'disk',
+            samples,
+            margin_left,
+            margin_top,
+            plot_w,
+            plot_h,
+            lambda sample: [
+                datetime.fromtimestamp(sample[0]).strftime("%H:%M:%S"),
+                f"{tr('disk_loading')}: {sample[3]:.1f}%",
+                f"{sample[1]:.1f}/{sample[2]:.1f} GB",
+            ],
+        )
 
         start_ts = datetime.fromtimestamp(samples[0][0]).strftime("%H:%M:%S")
         end_ts = datetime.fromtimestamp(samples[-1][0]).strftime("%H:%M:%S")
@@ -1538,6 +1688,22 @@ class SystemTrayApp:
         cr.move_to(width - margin_right - _text_width(ext), 12)
         cr.show_text(values_text)
 
+        self._draw_graph_hover_info(
+            widget,
+            cr,
+            'net',
+            samples,
+            margin_left,
+            margin_top,
+            plot_w,
+            plot_h,
+            lambda sample: [
+                datetime.fromtimestamp(sample[0]).strftime("%H:%M:%S"),
+                f"↓ {sample[1]:.2f} MB/s",
+                f"↑ {sample[2]:.2f} MB/s",
+            ],
+        )
+
         start_ts = datetime.fromtimestamp(samples[0][0]).strftime("%H:%M:%S")
         end_ts = datetime.fromtimestamp(samples[-1][0]).strftime("%H:%M:%S")
 
@@ -1673,6 +1839,21 @@ class SystemTrayApp:
         cr.move_to(width - margin_right - _text_width(ext), 12)
         cr.show_text(values_text)
 
+        self._draw_graph_hover_info(
+            widget,
+            cr,
+            'keyboard',
+            samples,
+            margin_left,
+            margin_top,
+            plot_w,
+            plot_h,
+            lambda sample: [
+                datetime.fromtimestamp(sample[0]).strftime("%H:%M:%S"),
+                f"{tr('keyboard_clicks')}: {sample[1]}",
+            ],
+        )
+
         start_ts = datetime.fromtimestamp(samples[0][0]).strftime("%H:%M:%S")
         end_ts = datetime.fromtimestamp(samples[-1][0]).strftime("%H:%M:%S")
 
@@ -1807,6 +1988,21 @@ class SystemTrayApp:
         ext = cr.text_extents(values_text)
         cr.move_to(width - margin_right - _text_width(ext), 12)
         cr.show_text(values_text)
+
+        self._draw_graph_hover_info(
+            widget,
+            cr,
+            'mouse',
+            samples,
+            margin_left,
+            margin_top,
+            plot_w,
+            plot_h,
+            lambda sample: [
+                datetime.fromtimestamp(sample[0]).strftime("%H:%M:%S"),
+                f"{tr('mouse_clicks')}: {sample[1]}",
+            ],
+        )
 
         start_ts = datetime.fromtimestamp(samples[0][0]).strftime("%H:%M:%S")
         end_ts = datetime.fromtimestamp(samples[-1][0]).strftime("%H:%M:%S")

--- a/app_core/app.py
+++ b/app_core/app.py
@@ -747,7 +747,7 @@ class SystemTrayApp:
         if self.cpu_graph_window:
             self.cpu_graph_window.set_title(f"{tr('cpu_info')} — {tr('system_status')}")
         if self.cpu_graph_hint_label:
-            self.cpu_graph_hint_label.set_text(self._zoom_hint_text())
+            self.cpu_graph_hint_label.set_text("")
         if self.cpu_graph_area:
             self.cpu_graph_area.queue_draw()
 
@@ -772,9 +772,6 @@ class SystemTrayApp:
     @staticmethod
     def _clamp(value: float, min_value: float, max_value: float) -> float:
         return max(min_value, min(max_value, value))
-
-    def _zoom_hint_text(self) -> str:
-        return "Колесо мыши: масштаб по горизонтали (точка под курсором)"
 
     def _visible_samples(self, graph_key: str, samples: list[tuple]) -> list[tuple]:
         if len(samples) <= 2:
@@ -989,7 +986,7 @@ class SystemTrayApp:
         if self.ram_graph_window:
             self.ram_graph_window.set_title(f"{tr('ram_loading')} — {tr('system_status')}")
         if self.ram_graph_hint_label:
-            self.ram_graph_hint_label.set_text(self._zoom_hint_text())
+            self.ram_graph_hint_label.set_text("")
         if self.ram_graph_area:
             self.ram_graph_area.queue_draw()
 
@@ -1126,7 +1123,7 @@ class SystemTrayApp:
         if self.swap_graph_window:
             self.swap_graph_window.set_title(f"{tr('swap_loading')} — {tr('system_status')}")
         if self.swap_graph_hint_label:
-            self.swap_graph_hint_label.set_text(self._zoom_hint_text())
+            self.swap_graph_hint_label.set_text("")
         if self.swap_graph_area:
             self.swap_graph_area.queue_draw()
 
@@ -1263,7 +1260,7 @@ class SystemTrayApp:
         if self.disk_graph_window:
             self.disk_graph_window.set_title(f"{tr('disk_loading')} — {tr('system_status')}")
         if self.disk_graph_hint_label:
-            self.disk_graph_hint_label.set_text(self._zoom_hint_text())
+            self.disk_graph_hint_label.set_text("")
         if self.disk_graph_area:
             self.disk_graph_area.queue_draw()
 
@@ -1401,7 +1398,7 @@ class SystemTrayApp:
         if self.net_graph_window:
             self.net_graph_window.set_title(f"{tr('lan_speed')} — {tr('system_status')}")
         if self.net_graph_hint_label:
-            self.net_graph_hint_label.set_text(self._zoom_hint_text())
+            self.net_graph_hint_label.set_text("")
         if self.net_graph_area:
             self.net_graph_area.queue_draw()
 
@@ -1548,7 +1545,7 @@ class SystemTrayApp:
         if self.keyboard_graph_window:
             self.keyboard_graph_window.set_title(f"{tr('keyboard_clicks')} — {tr('system_status')}")
         if self.keyboard_graph_hint_label:
-            self.keyboard_graph_hint_label.set_text(self._zoom_hint_text())
+            self.keyboard_graph_hint_label.set_text("")
         if self.keyboard_graph_area:
             self.keyboard_graph_area.queue_draw()
 
@@ -1683,7 +1680,7 @@ class SystemTrayApp:
         if self.mouse_graph_window:
             self.mouse_graph_window.set_title(f"{tr('mouse_clicks')} — {tr('system_status')}")
         if self.mouse_graph_hint_label:
-            self.mouse_graph_hint_label.set_text(self._zoom_hint_text())
+            self.mouse_graph_hint_label.set_text("")
         if self.mouse_graph_area:
             self.mouse_graph_area.queue_draw()
 

--- a/app_core/app.py
+++ b/app_core/app.py
@@ -167,13 +167,13 @@ class SystemTrayApp:
         self.mouse_history = deque(maxlen=graph_points)
 
         self.graph_zoom_state: Dict[str, Dict[str, float]] = {
-            'cpu': {'scale': 1.0, 'center': 1.0},
-            'ram': {'scale': 1.0, 'center': 1.0},
-            'swap': {'scale': 1.0, 'center': 1.0},
-            'disk': {'scale': 1.0, 'center': 1.0},
-            'net': {'scale': 1.0, 'center': 1.0},
-            'keyboard': {'scale': 1.0, 'center': 1.0},
-            'mouse': {'scale': 1.0, 'center': 1.0},
+            'cpu': {'scale': 1.0, 'center': 1.0, 'dragging': 0.0, 'last_x': 0.0},
+            'ram': {'scale': 1.0, 'center': 1.0, 'dragging': 0.0, 'last_x': 0.0},
+            'swap': {'scale': 1.0, 'center': 1.0, 'dragging': 0.0, 'last_x': 0.0},
+            'disk': {'scale': 1.0, 'center': 1.0, 'dragging': 0.0, 'last_x': 0.0},
+            'net': {'scale': 1.0, 'center': 1.0, 'dragging': 0.0, 'last_x': 0.0},
+            'keyboard': {'scale': 1.0, 'center': 1.0, 'dragging': 0.0, 'last_x': 0.0},
+            'mouse': {'scale': 1.0, 'center': 1.0, 'dragging': 0.0, 'last_x': 0.0},
         }
 
         if self.visibility_settings.get('logging_enabled', True) and not LOG_FILE.exists():
@@ -796,8 +796,18 @@ class SystemTrayApp:
         return samples[start:end]
 
     def _connect_graph_zoom(self, area: Gtk.DrawingArea, graph_key: str) -> None:
-        area.set_events(area.get_events() | Gdk.EventMask.SCROLL_MASK)
+        area.set_events(
+            area.get_events()
+            | Gdk.EventMask.SCROLL_MASK
+            | Gdk.EventMask.BUTTON_PRESS_MASK
+            | Gdk.EventMask.BUTTON_RELEASE_MASK
+            | Gdk.EventMask.POINTER_MOTION_MASK
+            | Gdk.EventMask.BUTTON1_MOTION_MASK
+        )
         area.connect('scroll-event', self._on_graph_scroll_event, graph_key)
+        area.connect('button-press-event', self._on_graph_button_press_event, graph_key)
+        area.connect('motion-notify-event', self._on_graph_motion_notify_event, graph_key)
+        area.connect('button-release-event', self._on_graph_button_release_event, graph_key)
 
     def _on_graph_scroll_event(self, widget, event, graph_key: str):
         state = self.graph_zoom_state.get(graph_key)
@@ -835,6 +845,48 @@ class SystemTrayApp:
         state['scale'] = new_scale
         state['center'] = self._clamp(new_center, 0.0, 1.0)
         widget.queue_draw()
+        return True
+
+    def _on_graph_button_press_event(self, _widget, event, graph_key: str):
+        if event.button != Gdk.BUTTON_PRIMARY:
+            return False
+        state = self.graph_zoom_state.get(graph_key)
+        if state is None:
+            return False
+        state['dragging'] = 1.0
+        state['last_x'] = float(getattr(event, 'x', 0.0))
+        return True
+
+    def _on_graph_motion_notify_event(self, widget, event, graph_key: str):
+        state = self.graph_zoom_state.get(graph_key)
+        if state is None or state.get('dragging', 0.0) < 0.5:
+            return False
+
+        width = max(1, widget.get_allocated_width())
+        old_scale = self._clamp(float(state.get('scale', 1.0)), 1.0, 40.0)
+        span = 1.0 / old_scale
+        if span >= 1.0:
+            state['last_x'] = float(getattr(event, 'x', 0.0))
+            return False
+
+        current_x = self._clamp(float(getattr(event, 'x', 0.0)), 0.0, float(width))
+        prev_x = self._clamp(float(state.get('last_x', current_x)), 0.0, float(width))
+        delta_x = current_x - prev_x
+        state['last_x'] = current_x
+
+        old_center = self._clamp(float(state.get('center', 1.0)), 0.0, 1.0)
+        new_center = old_center - (delta_x / width) * span
+        state['center'] = self._clamp(new_center, span / 2, 1.0 - span / 2)
+        widget.queue_draw()
+        return True
+
+    def _on_graph_button_release_event(self, _widget, event, graph_key: str):
+        if event.button != Gdk.BUTTON_PRIMARY:
+            return False
+        state = self.graph_zoom_state.get(graph_key)
+        if state is None:
+            return False
+        state['dragging'] = 0.0
         return True
 
     def _draw_cpu_graph(self, widget, cr):


### PR DESCRIPTION
### Motivation
- Пользователи должны иметь возможность масштабировать графики по горизонтали и выбирать место масштабирования простым прокручиванием колеса мыши.

### Description
- Подключен `Gdk` и добавлено общее состояние `graph_zoom_state` для каждого графика (масштаб и центр просмотра). 
- Реализованы вспомогательные методы `_clamp`, `_zoom_hint_text`, `_visible_samples`, `_connect_graph_zoom` и `_on_graph_scroll_event` для обработки зума и вычисления видимого окна данных. 
- Для всех `DrawingArea` графиков (CPU, RAM, Swap, Disk, Network, Keyboard, Mouse) подключён обработчик `scroll-event` и в подсказках установлена инструкция по использованию колеса мыши. 
- Отрисовка графиков изменена: вместо полного набора данных рисуется только окно видимых сэмплов через вызов `self._visible_samples(...)`, что обеспечивает горизонтальный зум относительно точки под курсором. 

### Testing
- Запущены существующие автоматические тесты через `pytest -q`, результат: `20 passed` (успешно).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b84c48fcc08326ac315f5d379b43b9)