### PR TITLE
Harden Telegram/Discord notifier config handling

### DIFF
--- a/notifications/discord.py
+++ b/notifications/discord.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 from typing import Optional
 
 import requests
@@ -22,7 +23,7 @@ class DiscordNotifier:
                 self.webhook_url = (config.get('DISCORD_WEBHOOK_URL') or '').strip() or None
                 self.enabled = bool(config.get('enabled', False))
                 self.notification_interval = self._normalize_interval(config.get('notification_interval', 3600))
-        except Exception as e:
+        except (OSError, json.JSONDecodeError, TypeError, ValueError) as e:
             print(f"Ошибка загрузки конфигурации Discord: {e}")
 
     def save_config(self, webhook_url: str, enabled: bool, interval: int) -> bool:
@@ -30,18 +31,18 @@ class DiscordNotifier:
             self.webhook_url = (webhook_url or '').strip() or None
             self.enabled = bool(enabled)
             self.notification_interval = self._normalize_interval(interval)
-            DISCORD_CONFIG_FILE.write_text(json.dumps({
+            DISCORD_CONFIG_FILE.parent.mkdir(parents=True, exist_ok=True)
+            config_payload = json.dumps({
                 'DISCORD_WEBHOOK_URL': self.webhook_url,
                 'enabled': self.enabled,
                 'notification_interval': self.notification_interval
-            }, indent=2), encoding="utf-8")
-            try:
-                import os
-                os.chmod(DISCORD_CONFIG_FILE, 0o600)
-            except Exception as e:
-                print(f"Ошибка: {e}")
+            }, indent=2)
+            temp_path = DISCORD_CONFIG_FILE.with_suffix(DISCORD_CONFIG_FILE.suffix + ".tmp")
+            temp_path.write_text(config_payload, encoding="utf-8")
+            temp_path.replace(DISCORD_CONFIG_FILE)
+            os.chmod(DISCORD_CONFIG_FILE, 0o600)
             return True
-        except Exception as e:
+        except OSError as e:
             print(f"Ошибка сохранения конфигурации Discord: {e}")
             return False
 

--- a/notifications/telegram.py
+++ b/notifications/telegram.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 import threading
 import time
 from typing import Optional, TYPE_CHECKING
@@ -37,7 +38,7 @@ class TelegramNotifier:
                 self.chat_id = (str(config.get('TELEGRAM_CHAT_ID') or '').strip() or None)
                 self.enabled = bool(config.get('enabled', False))
                 self.notification_interval = self._normalize_interval(config.get('notification_interval', 3600))
-        except Exception as e:
+        except (OSError, json.JSONDecodeError, TypeError, ValueError) as e:
             print(f"Ошибка загрузки конфигурации Telegram: {e}")
 
     def save_config(self, token: str, chat_id: str, enabled: bool, interval: int) -> bool:
@@ -46,19 +47,19 @@ class TelegramNotifier:
             self.chat_id = chat_id.strip() if chat_id else None
             self.enabled = bool(enabled)
             self.notification_interval = self._normalize_interval(interval)
-            TELEGRAM_CONFIG_FILE.write_text(json.dumps({
+            TELEGRAM_CONFIG_FILE.parent.mkdir(parents=True, exist_ok=True)
+            config_payload = json.dumps({
                 'TELEGRAM_BOT_TOKEN': self.token,
                 'TELEGRAM_CHAT_ID': self.chat_id,
                 'enabled': self.enabled,
                 'notification_interval': self.notification_interval
-            }, indent=2), encoding="utf-8")
-            try:
-                import os
-                os.chmod(TELEGRAM_CONFIG_FILE, 0o600)
-            except Exception:
-                pass
+            }, indent=2)
+            temp_path = TELEGRAM_CONFIG_FILE.with_suffix(TELEGRAM_CONFIG_FILE.suffix + ".tmp")
+            temp_path.write_text(config_payload, encoding="utf-8")
+            temp_path.replace(TELEGRAM_CONFIG_FILE)
+            os.chmod(TELEGRAM_CONFIG_FILE, 0o600)
             return True
-        except Exception as e:
+        except OSError as e:
             print(f"Ошибка сохранения конфигурации Telegram: {e}")
             return False
 


### PR DESCRIPTION
### Motivation
- Уменьшить хрупкость работы с конфигами нотификаторов и исключить широкие `except Exception`, которые скрывают ожидаемые ошибки при чтении/записи.
- Снизить риск повреждения конфигурационных файлов при прерывании записи и гарантировать корректные права доступа.

### Description
- Жёстко ограничил перехват ошибок при загрузке конфигов в `notifications/telegram.py` и `notifications/discord.py`, заменив `except Exception` на `except (OSError, json.JSONDecodeError, TypeError, ValueError)` и сохранил информативный вывод ошибок. 
- При сохранении конфигов добавил создание директории через `parent.mkdir(parents=True, exist_ok=True)` чтобы избежать отказа при отсутствии пути. 
- Перешёл на атомарную запись с использованием временного файла и `replace()` (`*.tmp` + `replace()`) чтобы уменьшить вероятность частично записанных файлов. 
- Добавил импорт `os` и вызов `os.chmod(..., 0o600)` для установки жёстких прав на файлы и поменял обработку ошибок записи на `except OSError`.

### Testing
- Запущены модульные тесты с `pytest -q` и все тесты прошли успешно (`20 passed`).
- Статический анализ выполнен через `ruff check notifications/telegram.py notifications/discord.py` и проверки прошли без ошибок.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69bd22ce3960832694f84c6375085964)