### PR TITLE
Add GNOME Companion panel, external command interface, and pauseable notifications

### DIFF
--- a/app_core/app.py
+++ b/app_core/app.py
@@ -34,6 +34,7 @@ from .constants import (
     ICON_FALLBACK,
     LOG_FILE,
     SETTINGS_FILE,
+    COMMAND_FILE,
     TIME_UPDATE_SEC,
     GRAPH_HISTORY_MINUTES_DEFAULT,
     GRAPH_HISTORY_MINUTES_MIN,
@@ -454,6 +455,7 @@ class SystemTrayApp:
             'language': None, 'logging_enabled': True,
             'show_power_off': True, 'show_reboot': True, 'show_lock': True, 'show_timer': True,
             'max_log_mb': 5, 'ping_network': True, 'show_system_info': True,
+            'notifications_paused': False,
             'graph_history_minutes': GRAPH_HISTORY_MINUTES_DEFAULT,
             'menu_order': MENU_ORDER_DEFAULT.copy(),
         }
@@ -507,6 +509,61 @@ class SystemTrayApp:
             if key not in unique:
                 unique.append(key)
         return unique
+
+    @staticmethod
+    def _safe_unlink(path: Path) -> None:
+        try:
+            path.unlink()
+        except FileNotFoundError:
+            pass
+        except Exception:
+            logger.exception("Не удалось удалить файл команды: %s", path)
+
+    def _toggle_notifications_pause(self) -> None:
+        paused = not bool(self.visibility_settings.get('notifications_paused', False))
+        self.visibility_settings['notifications_paused'] = paused
+        self.save_settings()
+        logger.info("Внешняя команда: уведомления %s", "пауза" if paused else "возобновлены")
+
+    def _open_graph_by_key(self, graph_key: str) -> bool:
+        openers = {
+            'cpu': self.show_cpu_graph,
+            'ram': self.show_ram_graph,
+            'swap': self.show_swap_graph,
+            'disk': self.show_disk_graph,
+            'net': self.show_net_graph,
+            'keyboard': self.show_keyboard_graph,
+            'mouse': self.show_mouse_graph,
+        }
+        opener = openers.get(graph_key)
+        if opener is None:
+            return False
+        opener(None)
+        return True
+
+    def _consume_external_command(self) -> None:
+        if not COMMAND_FILE.exists():
+            return
+
+        try:
+            payload = json.loads(COMMAND_FILE.read_text(encoding="utf-8"))
+            action = str(payload.get("action", "")).strip()
+        except Exception:
+            logger.exception("Некорректный файл внешней команды: %s", COMMAND_FILE)
+            self._safe_unlink(COMMAND_FILE)
+            return
+
+        try:
+            if action == "toggle_notifications_pause":
+                self._toggle_notifications_pause()
+            elif action == "open_graph":
+                graph = str(payload.get("graph", "")).strip().lower()
+                if not self._open_graph_by_key(graph):
+                    logger.warning("Неизвестный тип графика для внешней команды: %s", graph)
+            else:
+                logger.warning("Неизвестная внешняя команда: %s", action)
+        finally:
+            self._safe_unlink(COMMAND_FILE)
 
     def update_menu_visibility(self) -> None:
         children = list(self.menu.get_children()) if hasattr(self, 'menu') else []
@@ -668,6 +725,7 @@ class SystemTrayApp:
 
     def update_info(self) -> bool:
         try:
+            self._consume_external_command()
             kbd, ms = self._safe_call(get_counts, (0, 0))
 
             cpu_temp = self._safe_call(SystemUsage.get_cpu_temp, 0)
@@ -690,7 +748,9 @@ class SystemTrayApp:
                             uptime_display, kbd, ms)
 
             now = time.time()
-            if (self.telegram_notifier.enabled and
+            notifications_paused = bool(self.visibility_settings.get('notifications_paused', False))
+
+            if (not notifications_paused and self.telegram_notifier.enabled and
                     now - self.last_telegram_notification_time >= self.telegram_notifier.notification_interval):
                 self._thread(self.send_telegram_notification,
                              cpu_temp, cpu_usage, ram_used, ram_total,
@@ -698,7 +758,7 @@ class SystemTrayApp:
                              net_recv_speed, net_sent_speed, uptime_display, kbd, ms)
                 self.last_telegram_notification_time = now
 
-            if (self.discord_notifier.enabled and
+            if (not notifications_paused and self.discord_notifier.enabled and
                     now - self.last_discord_notification_time >= self.discord_notifier.notification_interval):
                 self._thread(self.send_discord_notification,
                              cpu_temp, cpu_usage, ram_used, ram_total,
@@ -2102,7 +2162,10 @@ class SystemTrayApp:
             if self.visibility_settings.get('tray_ram', True):
                 tray_parts.append(f"{tr('ram_loading')}: {ram_used:.1f}GB")
             tray_text = "  ".join(tray_parts)
-            if self.telegram_notifier.enabled or self.discord_notifier.enabled:
+            notifications_paused = bool(self.visibility_settings.get('notifications_paused', False))
+            if notifications_paused:
+                tray_text = "⏸  " + tray_text
+            elif self.telegram_notifier.enabled or self.discord_notifier.enabled:
                 tray_text = "⤴  " + tray_text
             self.indicator.set_label(tray_text, "")
         except Exception as e:

--- a/app_core/constants.py
+++ b/app_core/constants.py
@@ -16,6 +16,7 @@ LOG_FILE = HOME / ".symo_log.txt"
 SETTINGS_FILE = HOME / ".symo_settings.json"
 TELEGRAM_CONFIG_FILE = HOME / ".symo_telegram.json"
 DISCORD_CONFIG_FILE = HOME / ".symo_discord.json"
+COMMAND_FILE = HOME / ".symo_command.json"
 
 MENU_ORDER_DEFAULT = [
     'cpu',

--- a/gnome_extension/extension.js
+++ b/gnome_extension/extension.js
@@ -1,4 +1,5 @@
 import Gio from 'gi://Gio';
+import GLib from 'gi://GLib';
 import St from 'gi://St';
 
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
@@ -7,29 +8,198 @@ import * as PopupMenu from 'resource:///org/gnome/shell/ui/popupMenu.js';
 
 const UUID = 'symo@olegegoism.github.io';
 const APP_BINARY = 'SyMo';
+const LOG_PATH = GLib.build_filenamev([GLib.get_home_dir(), '.symo_log.txt']);
+const COMMAND_PATH = GLib.build_filenamev([GLib.get_home_dir(), '.symo_command.json']);
 
-class SyMoLauncherIndicator extends PanelMenu.Button {
+const POLL_SEC = 3;
+const THRESHOLDS = {
+    cpu: 90,
+    ram: 90,
+    disk: 95,
+    temp: 85,
+};
+
+function readFileText(path) {
+    try {
+        const file = Gio.File.new_for_path(path);
+        const [ok, contents] = file.load_contents(null);
+        if (!ok)
+            return '';
+        return new TextDecoder().decode(contents);
+    } catch (_error) {
+        return '';
+    }
+}
+
+function writeJson(path, payload) {
+    try {
+        const file = Gio.File.new_for_path(path);
+        const text = JSON.stringify(payload);
+        file.replace_contents(
+            text,
+            null,
+            false,
+            Gio.FileCreateFlags.REPLACE_DESTINATION,
+            null
+        );
+        return true;
+    } catch (error) {
+        log(`[${UUID}] Failed to write command: ${error}`);
+        return false;
+    }
+}
+
+function parseLatestMetrics(logText) {
+    const lines = (logText || '').trim().split('\n').filter(Boolean);
+    const line = lines.length > 0 ? lines[lines.length - 1] : '';
+    if (!line)
+        return null;
+
+    const cpuMatch = line.match(/CPU:\s*(\d+)%\s*(-?\d+)°C/i);
+    const ramMatch = line.match(/RAM:\s*([\d.]+)\/([\d.]+)\s*GB/i);
+    const diskMatch = line.match(/Disk:\s*([\d.]+)\/([\d.]+)\s*GB/i);
+    if (!cpuMatch || !ramMatch || !diskMatch)
+        return null;
+
+    const cpuUsage = Number.parseFloat(cpuMatch[1]);
+    const cpuTemp = Number.parseFloat(cpuMatch[2]);
+    const ramUsed = Number.parseFloat(ramMatch[1]);
+    const ramTotal = Math.max(0.0001, Number.parseFloat(ramMatch[2]));
+    const diskUsed = Number.parseFloat(diskMatch[1]);
+    const diskTotal = Math.max(0.0001, Number.parseFloat(diskMatch[2]));
+    const ramPercent = (ramUsed / ramTotal) * 100;
+    const diskPercent = (diskUsed / diskTotal) * 100;
+
+    return {
+        cpuUsage,
+        cpuTemp,
+        ramPercent,
+        diskPercent,
+        rawLine: line,
+    };
+}
+
+class SyMoCompanionIndicator extends PanelMenu.Button {
     constructor() {
-        super(0.0, 'SyMo Launcher');
+        super(0.0, 'SyMo Companion');
 
+        this._pollSourceId = 0;
+        this._notificationsPaused = false;
+
+        this._content = new St.BoxLayout({style_class: 'panel-status-menu-box'});
         this._icon = new St.Icon({
             icon_name: 'utilities-system-monitor-symbolic',
             style_class: 'system-status-icon',
         });
-        this.add_child(this._icon);
+        this._label = new St.Label({
+            text: 'CPU --% RAM --%',
+            y_align: St.Align.MIDDLE,
+            style: 'margin-left: 6px;',
+        });
+
+        this._content.add_child(this._icon);
+        this._content.add_child(this._label);
+        this.add_child(this._content);
+
+        this._summaryItem = new PopupMenu.PopupMenuItem('No metrics yet');
+        this._summaryItem.setSensitive(false);
+        this.menu.addMenuItem(this._summaryItem);
+
+        this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
+
+        this._pauseItem = new PopupMenu.PopupMenuItem('Pause notifications');
+        this._pauseItem.connect('activate', () => this._toggleNotificationsPause());
+        this.menu.addMenuItem(this._pauseItem);
+
+        const openGraphsMenu = new PopupMenu.PopupSubMenuMenuItem('Open graph');
+        this._addGraphAction(openGraphsMenu.menu, 'CPU', 'cpu');
+        this._addGraphAction(openGraphsMenu.menu, 'RAM', 'ram');
+        this._addGraphAction(openGraphsMenu.menu, 'Swap', 'swap');
+        this._addGraphAction(openGraphsMenu.menu, 'Disk', 'disk');
+        this._addGraphAction(openGraphsMenu.menu, 'Network', 'net');
+        this._addGraphAction(openGraphsMenu.menu, 'Keyboard', 'keyboard');
+        this._addGraphAction(openGraphsMenu.menu, 'Mouse', 'mouse');
+        this.menu.addMenuItem(openGraphsMenu);
+
+        this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
 
         this._openItem = new PopupMenu.PopupMenuItem('Open SyMo');
         this._openItem.connect('activate', () => this._launchSyMo());
         this.menu.addMenuItem(this._openItem);
 
-        this._separator = new PopupMenu.PopupSeparatorMenuItem();
-        this.menu.addMenuItem(this._separator);
-
-        this._aboutItem = new PopupMenu.PopupMenuItem('About SyMo');
+        this._aboutItem = new PopupMenu.PopupMenuItem('About companion');
         this._aboutItem.connect('activate', () => {
-            Main.notify('SyMo', 'SyMo launcher extension is active.');
+            Main.notify('SyMo', 'Companion mode is active: panel metrics + quick actions.');
         });
         this.menu.addMenuItem(this._aboutItem);
+
+        this._refreshMetrics();
+        this._pollSourceId = GLib.timeout_add_seconds(
+            GLib.PRIORITY_DEFAULT,
+            POLL_SEC,
+            () => this._refreshMetrics()
+        );
+    }
+
+    _addGraphAction(menu, title, graphKey) {
+        const item = new PopupMenu.PopupMenuItem(title);
+        item.connect('activate', () => this._sendCommand({
+            action: 'open_graph',
+            graph: graphKey,
+            requested_at: Date.now(),
+        }));
+        menu.addMenuItem(item);
+    }
+
+    _sendCommand(payload) {
+        if (!writeJson(COMMAND_PATH, payload)) {
+            Main.notify('SyMo', 'Unable to send command to SyMo companion.');
+            return;
+        }
+
+        if (payload.action === 'open_graph')
+            this._launchSyMo();
+    }
+
+    _toggleNotificationsPause() {
+        this._notificationsPaused = !this._notificationsPaused;
+        this._pauseItem.label.text = this._notificationsPaused
+            ? 'Resume notifications'
+            : 'Pause notifications';
+        this._sendCommand({
+            action: 'toggle_notifications_pause',
+            requested_at: Date.now(),
+        });
+    }
+
+    _refreshMetrics() {
+        const metrics = parseLatestMetrics(readFileText(LOG_PATH));
+        if (!metrics) {
+            this._label.text = 'CPU --% RAM --%';
+            this._summaryItem.label.text = 'No metrics yet (enable logging in SyMo).';
+            this._icon.icon_name = 'utilities-system-monitor-symbolic';
+            return GLib.SOURCE_CONTINUE;
+        }
+
+        this._label.text = `CPU ${metrics.cpuUsage.toFixed(0)}% RAM ${metrics.ramPercent.toFixed(0)}%`;
+        this._summaryItem.label.text =
+            `CPU ${metrics.cpuUsage.toFixed(0)}% (${metrics.cpuTemp.toFixed(0)}°C) · RAM ${metrics.ramPercent.toFixed(0)}% · Disk ${metrics.diskPercent.toFixed(0)}%`;
+
+        const breached = (
+            metrics.cpuUsage >= THRESHOLDS.cpu ||
+            metrics.ramPercent >= THRESHOLDS.ram ||
+            metrics.diskPercent >= THRESHOLDS.disk ||
+            metrics.cpuTemp >= THRESHOLDS.temp
+        );
+
+        if (breached) {
+            this._icon.icon_name = 'dialog-warning-symbolic';
+            this._summaryItem.label.text = `⚠ ${this._summaryItem.label.text}`;
+        } else {
+            this._icon.icon_name = 'utilities-system-monitor-symbolic';
+        }
+
+        return GLib.SOURCE_CONTINUE;
     }
 
     _launchSyMo() {
@@ -45,11 +215,19 @@ class SyMoLauncherIndicator extends PanelMenu.Button {
             Main.notify('SyMo', 'Unable to start SyMo. Ensure SyMo is installed and available in PATH.');
         }
     }
+
+    destroy() {
+        if (this._pollSourceId) {
+            GLib.Source.remove(this._pollSourceId);
+            this._pollSourceId = 0;
+        }
+        super.destroy();
+    }
 }
 
 export default class SyMoExtension {
     enable() {
-        this._indicator = new SyMoLauncherIndicator();
+        this._indicator = new SyMoCompanionIndicator();
         Main.panel.addToStatusArea(UUID, this._indicator);
     }
 

--- a/gnome_extension/metadata.json
+++ b/gnome_extension/metadata.json
@@ -1,8 +1,8 @@
 {
   "uuid": "symo@olegegoism.github.io",
-  "name": "SyMo Launcher",
-  "description": "GNOME Shell panel launcher for the SyMo system monitor app.",
+  "name": "SyMo Companion",
+  "description": "GNOME Shell companion for SyMo with panel metrics, quick actions, and alert indicator.",
   "shell-version": ["45", "46", "47", "48"],
-  "version": 1,
+  "version": 2,
   "url": "https://github.com/OlegEgoism/SyMo"
 }

--- a/tests/test_gnome_companion_extension.py
+++ b/tests/test_gnome_companion_extension.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+
+
+def test_extension_exposes_companion_actions():
+    code = Path("gnome_extension/extension.js").read_text(encoding="utf-8")
+    assert "Pause notifications" in code
+    assert "action: 'open_graph'" in code
+    assert "toggle_notifications_pause" in code
+    assert "dialog-warning-symbolic" in code
+
+
+def test_app_consumes_external_commands():
+    code = Path("app_core/app.py").read_text(encoding="utf-8")
+    assert "def _consume_external_command" in code
+    assert "COMMAND_FILE" in code
+    assert "toggle_notifications_pause" in code
+    assert "open_graph" in code


### PR DESCRIPTION
### Motivation
- Provide a lightweight GNOME panel companion that displays recent metrics, quick actions to open graphs, and an alert indicator. 
- Add an external command channel so the GNOME companion (or other tools) can request actions in the main SyMo app. 
- Allow pausing/resuming external notifications from the app and reflect that state in the tray label. 

### Description
- Introduces `COMMAND_FILE` constant (`~/.symo_command.json`) and implements `_consume_external_command`, `_safe_unlink`, `_toggle_notifications_pause`, and `_open_graph_by_key` in `app_core/app.py` to process commands like `toggle_notifications_pause` and `open_graph` and to remove the command file after processing. 
- Adds `notifications_paused` to settings and skips sending Telegram/Discord notifications while paused; updates tray label to show a pause icon when paused. 
- Calls `_consume_external_command` from `update_info` so external commands are handled periodically, and logs warnings for unknown commands. 
- Adds a GNOME Shell companion indicator (`gnome_extension/extension.js`) that periodically parses the latest line of the SyMo log for metrics, shows quick actions to open specific graphs, and writes JSON commands to `~/.symo_command.json`; it also provides a toggle to pause/resume notifications. 
- Updates extension metadata (`gnome_extension/metadata.json`) with new name/description and bumped version, and replaces the old launcher indicator with the companion indicator. 
- Adds tests (`tests/test_gnome_companion_extension.py`) that assert the new companion actions and the app-side command consumer exist in the code. 

### Testing
- Ran the new unit tests in `tests/test_gnome_companion_extension.py` with `pytest`, and the tests passed. 
- Manual smoke checks performed by reading/writing the `~/.symo_command.json` file and verifying that the app logs and tray label reflect the `notifications_paused` state (no automated failures observed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c6f34458e483269a88acebc81f2a6b)